### PR TITLE
Constrain reference length calculation to the x-axis

### DIFF
--- a/Geometry/assembly.py
+++ b/Geometry/assembly.py
@@ -422,7 +422,9 @@ class Assembly():
             #self.mesh.original_nodes = np.copy(self.mesh.nodes)
             self.inside_shock = np.zeros(len(self.mesh.nodes))
 
-        self.Lref = np.max(self.mesh.xmax-self.mesh.xmin)
+        # self.Lref = np.max(self.mesh.xmax-self.mesh.xmin)
+        self.Lref = (self.mesh.xmax-self.mesh.xmin)[0]
+
 
         self.aerothermo = Aerothermo(len(self.mesh.facets))
         self.aerothermo_cfd = Aerothermo(len(self.mesh.nodes))


### PR DESCRIPTION
This pull request fixes issue #26 by correcting the calculation of the reference length to align properly with the x-axis, ensuring accurate geometric representation in simulations.