### PR TITLE
Adaptive dynamics postprocessing and other QoL features

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 launch.json
 link.cfg
 Executables
+*.xml
+settings.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.pyc
 launch.json
-link.cfg
+link*.cfg
 Executables
+TITAN_sol
 *.xml
 settings.json

--- a/Aerothermo/aerothermo.py
+++ b/Aerothermo/aerothermo.py
@@ -1507,6 +1507,6 @@ def compute_per_facet_flow_dir(assembly,flow_direction, do_pfm=False):
             velocity_resultant[i_centroid,:] -= np.cross(angular_velocity_vector,(facet_centroid-assembly.mesh.COG))
         
     mach_resultant = np.linalg.norm(velocity_resultant,axis=1)/free.sound
-    for i_v, v in enumerate(velocity_resultant):
-        velocity_resultant[i_v,:] = v / np.linalg.norm(v)
+    velocity_norm = np.linalg.norm(velocity_resultant, axis=1, keepdims=True)
+    velocity_resultant = velocity_resultant/velocity_norm
     return velocity_resultant,mach_resultant

--- a/Aerothermo/aerothermo.py
+++ b/Aerothermo/aerothermo.py
@@ -23,6 +23,7 @@ from Dynamics.frames import *
 from scipy import special
 from copy import copy
 from Aerothermo import su2, switch, sparta
+from Geometry.enclosure import check_enclosure
 from scipy.interpolate import interp1d, PchipInterpolator
 from scipy.spatial.transform import Rotation as Rot
 import trimesh
@@ -319,7 +320,7 @@ def compute_aerothermo(titan, options):
         mix_properties.compute_stagnation(assembly.freestream, options.freestream)
 
     if options.fidelity.lower() == 'low':
-        compute_low_fidelity_aerothermo(titan.assembly, options)
+        compute_low_fidelity_aerothermo(titan.assembly, options, titan.iter)
     elif options.fidelity.lower() == 'high':
 
         if  (assembly.freestream.knudsen <= options.aerothermo.knc_pressure):
@@ -419,7 +420,7 @@ def compute_aerothermodynamics(assembly, obj, index, flow_direction, options):
         assembly.aerothermo.heatflux[index] = aerothermodynamics_module_ice_giants(assembly, index, flow_direction, options)
 
 
-def compute_low_fidelity_aerothermo(assembly, options) :
+def compute_low_fidelity_aerothermo(assembly, options, iteration):
     """
     Low-fidelity aerothermo computation
 
@@ -453,8 +454,12 @@ def compute_low_fidelity_aerothermo(assembly, options) :
         _assembly.quaternion_prev = _assembly.quaternion #to be used in thermal model
 
         #_assembly.freestream.per_facet_mach = compute_per_facet_mach(_assembly,flow_direction)
-
-        index = ray_trace(_assembly,flow_direction,n, options)
+        if check_enclosure(assembly,options,it, iteration):
+            index = ray_trace(_assembly,flow_direction,n, options)
+        else:
+            index = np.array([],dtype=np.int16)#np.zeros(len(_assembly.mesh.facets),dtype=np.int16)
+            _assembly.freestream.per_facet_mach =  np.ones(len(_assembly.mesh.facets)) *_assembly.freestream.mach
+            _assembly.aerothermo.partial_factor = np.zeros(len(_assembly.mesh.facets))
 
         _assembly.aero_index = index
         compute_aerothermodynamics(_assembly, [], index, flow_direction, options)

--- a/Aerothermo/aerothermo.py
+++ b/Aerothermo/aerothermo.py
@@ -1502,9 +1502,9 @@ def compute_per_facet_flow_dir(assembly,flow_direction, do_pfm=False):
     velocity_resultant = free.mach*free.sound*np.tile(flow_direction,[len(assembly.mesh.facet_area),1])
     if do_pfm:
         angular_velocity_vector = np.array([assembly.roll_vel,assembly.pitch_vel,assembly.yaw_vel])
-
-        for i_centroid, facet_centroid in enumerate(assembly.mesh.facet_COG):
-            velocity_resultant[i_centroid,:] -= np.cross(angular_velocity_vector,(facet_centroid-assembly.mesh.COG))
+        centroid_radii =  assembly.mesh.facet_COG - assembly.mesh.COG
+        tangential_velocity = np.cross(angular_velocity_vector,centroid_radii)
+        velocity_resultant -= tangential_velocity
         
     mach_resultant = np.linalg.norm(velocity_resultant,axis=1)/free.sound
     velocity_norm = np.linalg.norm(velocity_resultant, axis=1, keepdims=True)

--- a/Config_template.cfg
+++ b/Config_template.cfg
@@ -34,7 +34,7 @@ Output_freq = 1
 Collision = False
 
 # Material file to use
-Material_file = material.xml
+Material_file = database_material.xml
 
 # Show a live plot of geodetic position and angle of attack, minor performance overhead
 Plot = True
@@ -470,9 +470,9 @@ Sideslip = 0.0
 #
 #If no trigger is specified, the joint does not undergo fragmentation
 
-Cube_A = [NAME = Cube_A.stl,         TYPE = Primitive,   MATERIAL = Unittest,   FENICS_ID = 1]]
-Cube_B = [NAME = Cube_B.stl,         TYPE = Primitive,   MATERIAL = Unittest,   FENICS_ID = 1]]
-Joint  = [NAME = Joint.stl,          TYPE = Joint,       MATERIAL = Unittest,   FENICS_ID = 1]]
+Cube_A = [NAME = Cube_A.stl,         TYPE = Primitive,   MATERIAL = Unittest]
+Cube_B = [NAME = Cube_B.stl,         TYPE = Primitive,   MATERIAL = Unittest]
+Joint  = [NAME = Joint.stl,          TYPE = Joint,       MATERIAL = Unittest,   TRIGGER_TYPE=Altitude, TRIGGER_VALUE=95000]
 
 
 #######################

--- a/Config_template.cfg
+++ b/Config_template.cfg
@@ -33,19 +33,30 @@ Output_freq = 1
 # (note implementation with new dynamics is unverified)
 Collision = False
 
+# Material file to use
+Material_file = material.xml
+
 # Show a live plot of geodetic position and angle of attack, minor performance overhead
 Plot = True
+
+# If using adaptive time stepping, the time frequency at which to generate data (0.0 to disable)
+Time_fidelity = 0.0
+
+# If time_fidelity > 0.0 and Dense_solutions = True TITAN will generate a
+# linearly interpolated surface solution for each data point.
+Dense_solutions = True
+
+# Specify a postprocess method here in order to postprocess each data point as they are generated
+# Comment out to disable
+#Postprocess_in_loop = WIND
 
 #######################
 #Trajectory block
 ######################
 
 [Trajectory]
-
-#To be implemented
-#Choosing Frame for dynamics (Inertial/Rotating)
-#The user needs to provide the below values with respect to the chosen frame:
-Frame = Inertial
+#Choosing Frame for dynamics (Geodetic/ECEF/ECI)
+Frame = Geodetic
 
 #Initial altitude [meters]
 Altitude = 100000
@@ -65,6 +76,10 @@ Latitude = 0
 #Initial Longitude [degree]
 Longitude = 0
 
+## If not using Geodetic frame the user can instead specify the state [metres, metres/second]
+# State = X, Y, Z, U, V, W
+## If using ECI the user must also specify the epoch
+# Epoch = yyyy/mm/dd HH:MM:SS
 
 #######################
 #Thermal block
@@ -98,6 +113,9 @@ Post_fragmentation_timestep = 1e-3
 
 # This represents a factor to "grow" the meshes of objects by to ensure collisions aren't complicated by thin surfaces
 Mesh_factor = 1e-4
+
+# The coefficient of restitution for collisions. 1 for fully elastic, 0 for fully inelastic.
+Elastic_factor = 0.99
 
 
 #######################
@@ -332,6 +350,9 @@ Far_size = 0.2
 
 # Element sizing for surface [m]
 Surf_size = 0.1
+
+# Mesh saving recursion limit, increase if saving/loading meshes causes errors
+#Recursion_limit = 5000
 
 ##########################################
 #SPARTA block - For high-fidelity simulations

--- a/Configuration/configuration.py
+++ b/Configuration/configuration.py
@@ -551,11 +551,8 @@ class Options():
         #:[int] Frequency of generating the output surface solution [per number of iterations]
         self.output_freq = 500
 
-        #:[float] Maximal time between dynamical outputs written to data.csv (seconds), disabled if 0.0
+        #:[float] Maximal time between dynamical outputs written to data_smooth.csv (seconds), disabled if 0.0
         self.time_fidelity = 0.0    
-
-        #:[float] Last time at which a dynamical output was written
-        self.last_output_time = 0.0
 
         #: [int] Current iteration
         self.current_iter = 0
@@ -1070,6 +1067,7 @@ def read_config_file(configParser, postprocess = "", emissions = ""):
     options.material_file  = get_config_value(configParser, 'database_material.xml', 'Options', 'Material_file', 'str')
     options.dynamic_plots  = get_config_value(configParser, False, 'Options', 'Plot', 'boolean')
     options.time_fidelity = get_config_value(configParser, options.time_fidelity, 'Options', 'Time_fidelity','float')
+    options.write_dense_solutions = get_config_value(configParser, False, 'Options','Dense_solutions', 'boolean' )
     options.time_counter   = 0
 
 
@@ -1292,7 +1290,7 @@ def read_config_file(configParser, postprocess = "", emissions = ""):
     if options.collision.flag:
         for assembly in titan.assembly: collision.generate_collision_mesh(assembly, options)
         collision.generate_collision_handler(titan, options)
-
+    if options.time_fidelity>0.0: titan.last_output_time=titan.time
     ### if options.FENICS:
     ###     fenics = TITAN.FENICS()
     ### else:

--- a/Configuration/configuration.py
+++ b/Configuration/configuration.py
@@ -121,6 +121,8 @@ class Dynamics():
         #: [seconds] Value of the time-step.
         self.time_step = time_step
 
+        #: [ECEF/Geodetic] Frame of specified input state
+        self.trajectory_frame = 'Geodetic'
         #: [str] Name of the propagator to be used in the dynamics (options - euler, ).
         self.propagator = propagator
 
@@ -547,7 +549,13 @@ class Options():
         self.save_freq = 500
 
         #:[int] Frequency of generating the output surface solution [per number of iterations]
-        self.output_freq = 500        
+        self.output_freq = 500
+
+        #:[float] Maximal time between dynamical outputs written to data.csv (seconds), disabled if 0.0
+        self.time_fidelity = 0.0    
+
+        #:[float] Last time at which a dynamical output was written
+        self.last_output_time = 0.0
 
         #: [int] Current iteration
         self.current_iter = 0
@@ -797,7 +805,7 @@ def check_initial_condition_array(initial_condition):
 
     return np.array(ids), np.array(condition)
 
-def read_trajectory(configParser):
+def read_trajectory(configParser, frame, planet=None):
     """
     Read the Trajectory specified in the config file
 
@@ -813,14 +821,62 @@ def read_trajectory(configParser):
     """
 
     trajectory = Trajectory()
+    if frame=='geodetic':
+        trajectory.altitude = get_config_value(configParser, trajectory.altitude, 'Trajectory', 'Altitude', 'float')
+        trajectory.velocity = get_config_value(configParser, trajectory.velocity, 'Trajectory', 'Velocity', 'float')
+        trajectory.gamma =    get_config_value(configParser, trajectory.gamma, 'Trajectory', 'Flight_path_angle', 'custom', 'angle')
+        trajectory.chi =      get_config_value(configParser, trajectory.chi, 'Trajectory', 'Heading_angle', 'custom', 'angle')
+        trajectory.latitude = get_config_value(configParser, trajectory.latitude, 'Trajectory', 'Latitude', 'custom', 'angle')
+        trajectory.longitude =get_config_value(configParser, trajectory.longitude, 'Trajectory', 'Longitude', 'custom', 'angle')
 
-    trajectory.altitude = get_config_value(configParser, trajectory.altitude, 'Trajectory', 'Altitude', 'float')
-    trajectory.velocity = get_config_value(configParser, trajectory.velocity, 'Trajectory', 'Velocity', 'float')
-    trajectory.gamma =    get_config_value(configParser, trajectory.gamma, 'Trajectory', 'Flight_path_angle', 'custom', 'angle')
-    trajectory.chi =      get_config_value(configParser, trajectory.chi, 'Trajectory', 'Heading_angle', 'custom', 'angle')
-    trajectory.latitude = get_config_value(configParser, trajectory.latitude, 'Trajectory', 'Latitude', 'custom', 'angle')
-    trajectory.longitude =get_config_value(configParser, trajectory.longitude, 'Trajectory', 'Longitude', 'custom', 'angle')
-    
+    elif frame=='ECEF' or frame=='ECI':
+            import pymap3d
+            state = get_config_value(configParser, '0,0,0,0,0,0', 'Trajectory', 'State', 'str').split(',')
+            state = np.array([float(value) for value in state])
+
+            if frame=='ECI': 
+                import datetime as dt
+                epoch = get_config_value(configParser, '1970/01/01 01:01:01', 'Trajectory', 'Epoch', 'str')
+                epoch = dt.datetime.strptime(epoch,'%Y/%m/%d %H:%M:%S')
+                state[:3] = pymap3d.eci2ecef(state[0],state[1],state[2],time=epoch)
+                rotMatrix = np.transpose([pymap3d.eci2ecef(1,0,0,epoch),
+                                           pymap3d.eci2ecef(0,1,0,epoch),
+                                           pymap3d.eci2ecef(0,0,1,epoch)])
+                state[3:] = rotMatrix @ state[3:] -np.cross([0,0,planet.omega()],state[:3])
+
+
+            [latitude, longitude, altitude] = pymap3d.ecef2geodetic(state[0], state[1], state[2],
+                                                                    ell=pymap3d.Ellipsoid(semimajor_axis = planet.ellipsoid()['a'], 
+                                                                                          semiminor_axis = planet.ellipsoid()['b']),
+                                                                    deg = False)
+            
+            [vEast, vNorth, vUp] = pymap3d.uvw2enu(state[3], state[4], state[5], latitude, longitude, deg=False)
+            velocity = np.linalg.norm(state[3:])
+            gamma = np.arcsin(np.dot(state[:3], state[3:])/(np.linalg.norm(state[:3])*velocity))
+            chi = np.arctan2(vEast,vNorth)
+
+            trajectory.altitude  =  altitude
+            trajectory.velocity  =  velocity
+            trajectory.gamma     =     gamma
+            trajectory.chi       =       chi
+            trajectory.latitude  =  latitude
+            trajectory.longitude = longitude
+
+            print('Converted state vector {}\nInto Geodetic trajectory with... \
+                  \nAltitude          | {}km\
+                  \nLatitude          | {}°\
+                  \nLongitude         | {}°\
+                  \nVelocity          | {}km/s\
+                  \nFlight Path Angle | {}°\
+                  \nHeading Angle     | {}°'.format(
+                      state.tolist(),
+                      np.round(altitude/1000,4),
+                      np.round(latitude*180/np.pi,4),
+                      np.round(longitude*180/np.pi,4),
+                      np.round(velocity/1000,4),
+                      np.round(gamma*180/np.pi,4),
+                      np.round(chi*180/np.pi,4),
+                  ))
     return trajectory
 
 def read_geometry(configParser, options):
@@ -1013,6 +1069,7 @@ def read_config_file(configParser, postprocess = "", emissions = ""):
     options.collision.flag = get_config_value(configParser, False, 'Options', 'Collision', 'boolean')
     options.material_file  = get_config_value(configParser, 'database_material.xml', 'Options', 'Material_file', 'str')
     options.dynamic_plots  = get_config_value(configParser, False, 'Options', 'Plot', 'boolean')
+    options.time_fidelity = get_config_value(configParser, options.time_fidelity, 'Options', 'Time_fidelity','float')
     options.time_counter   = 0
 
 
@@ -1092,6 +1149,8 @@ def read_config_file(configParser, postprocess = "", emissions = ""):
     #Read meshing options
     options.meshing.far_size  = get_config_value(configParser, 0.5, 'Mesh', 'Far_size', 'float')
     options.meshing.surf_size = get_config_value(configParser, 100, 'Mesh', 'Surf_size', 'float')
+    options.meshing.recursion = get_config_value(configParser, sys.getrecursionlimit(), 'Mesh', 'Recursion_limit', 'int')
+    sys.setrecursionlimit(options.meshing.recursion)
 
     #Read Freestream options
     options.freestream.model =  get_config_value(configParser, options.freestream.model, 'Freestream', 'Model', 'str')
@@ -1192,7 +1251,8 @@ def read_config_file(configParser, postprocess = "", emissions = ""):
 
     else:
         #Read the initial trajectory details
-        trajectory = read_trajectory(configParser)
+        options.dynamics.trajectory_frame = get_config_value(configParser, options.dynamics.trajectory_frame, 'Trajectory', 'Frame', 'str')
+        trajectory = read_trajectory(configParser, options.dynamics.trajectory_frame, options.planet)
 
         if options.load_mesh:
             titan = options.read_mesh()

--- a/Configuration/configuration.py
+++ b/Configuration/configuration.py
@@ -122,7 +122,7 @@ class Dynamics():
         self.time_step = time_step
 
         #: [ECEF/Geodetic] Frame of specified input state
-        self.trajectory_frame = 'Geodetic'
+        self.trajectory_frame = 'geodetic'
         #: [str] Name of the propagator to be used in the dynamics (options - euler, ).
         self.propagator = propagator
 
@@ -818,7 +818,7 @@ def read_trajectory(configParser, frame, planet=None):
     """
 
     trajectory = Trajectory()
-    if frame=='geodetic':
+    if frame.lower()=='geodetic':
         trajectory.altitude = get_config_value(configParser, trajectory.altitude, 'Trajectory', 'Altitude', 'float')
         trajectory.velocity = get_config_value(configParser, trajectory.velocity, 'Trajectory', 'Velocity', 'float')
         trajectory.gamma =    get_config_value(configParser, trajectory.gamma, 'Trajectory', 'Flight_path_angle', 'custom', 'angle')
@@ -826,12 +826,12 @@ def read_trajectory(configParser, frame, planet=None):
         trajectory.latitude = get_config_value(configParser, trajectory.latitude, 'Trajectory', 'Latitude', 'custom', 'angle')
         trajectory.longitude =get_config_value(configParser, trajectory.longitude, 'Trajectory', 'Longitude', 'custom', 'angle')
 
-    elif frame=='ECEF' or frame=='ECI':
+    elif frame.lower()=='ecef' or frame.lower()=='eci':
             import pymap3d
             state = get_config_value(configParser, '0,0,0,0,0,0', 'Trajectory', 'State', 'str').split(',')
             state = np.array([float(value) for value in state])
 
-            if frame=='ECI': 
+            if frame.lower()=='eci': 
                 import datetime as dt
                 epoch = get_config_value(configParser, '1970/01/01 01:01:01', 'Trajectory', 'Epoch', 'str')
                 epoch = dt.datetime.strptime(epoch,'%Y/%m/%d %H:%M:%S')
@@ -1093,6 +1093,8 @@ def read_config_file(configParser, postprocess = "", emissions = ""):
     options.dynamics.t_end = get_config_value(configParser, options.iters*options.dynamics.time_step, 'Time', 'Adaptive_end_time', 'float')
     options.dynamics.dt_initial = get_config_value(configParser, 0.1*options.dynamics.time_step, 'Time', 'Adaptive_dt_init', 'float')
 
+    if not (options.dynamics.propagator=='RK23' or options.dynamics.propagator=='RK45' or options.dynamics.propagator=='DOP853'):
+        options.time_fidelity = 0.0
     if 'adapt' in options.dynamics.propagator.lower(): 
         options.dynamics.acceleration_threshold = get_config_value(configParser, 0.05, 'Time', 'Spin_threshold', 'float')
         options.dynamics.tumbling_criterion = get_config_value(configParser, 0.0, 'Time', 'Tumble_threshold', 'float')

--- a/Configuration/configuration.py
+++ b/Configuration/configuration.py
@@ -1097,9 +1097,11 @@ def read_config_file(configParser, postprocess = "", emissions = ""):
     options.dynamics.time_step  = get_config_value(configParser, options.dynamics.time_step, 'Time', 'Time_step', 'float')
     options.dynamics.propagator = get_config_value(configParser, options.dynamics.propagator, 'Time', 'Time_integration', 'str')
 
-    if options.dynamics.propagator=='help': 
-        print(options.dynamics.prop_warning)
-        options.dynamics.propagator='euler'
+    if options.dynamics.propagator=='help':
+        options.dynamics.propagator = get_config_value(configParser, options.dynamics.propagator, 'Time', 'Propagator', 'str')
+        if options.dynamics.propagator=='help':
+            print(options.dynamics.prop_warning)
+            options.dynamics.propagator='euler'
 
     options.dynamics.prop_func =  propagation.get_integrator_func(options,options.dynamics.propagator.lower())
     options.dynamics.dt_max = get_config_value(configParser, 10*options.dynamics.time_step, 'Time', 'Adaptive_dt_max', 'float')

--- a/Configuration/configuration.py
+++ b/Configuration/configuration.py
@@ -707,6 +707,7 @@ class Options():
             print('Mesh loading failed at recursion limit: {}'.format(recursion_limit))
             recursion_limit=int(np.ceil(1.1*recursion_limit))
             sys.setrecursionlimit(recursion_limit)
+            titan = pickle.load(infile)
         infile.close()
 
         return titan
@@ -909,11 +910,19 @@ def read_geometry(configParser, options):
             for name, value in configParser.items(section):
                 value = value.replace('[','').replace(']','').replace(' ','').split(",")
                 object_type = [s for s in value if "type=" in s.lower()][0].split("=")[1]
+                try:
+                    alpha = float([s for s in value if "alpha=" in s.lower()][0].split("=")[1])
+                except:
+                    alpha = 1.0
 
                 if object_type == 'Primitive':
                     object_path = path+[s for s in value if "name=" in s.lower()][0].split("=")[1]
                     material= [s for s in value if "material=" in s.lower()][0].split("=")[1]
-                    
+                    try:
+                        enclosure = int([s for s in value if "enclosure=" in s.lower()][0].split("=")[1])
+                        print('Warning! Enclosure system is unverified and still in active development!!')
+                    except:
+                        enclosure = 0
 
                     try:
                         inner_stl_file = [s for s in value if "inner_stl=" in s.lower()][0].split("=")[1]
@@ -955,7 +964,8 @@ def read_geometry(configParser, options):
                         print('Need to set up BLOOM if using PATO!'); exit()
                     
                     objects.insert_component(filename = object_path, file_type = object_type, trigger_type = trigger_type, trigger_value = float(trigger_value), 
-                        fenics_bc_id = fenics_bc_id, inner_stl = inner_path, material = material, temperature = temperature, options = options, global_ID = obj_global_ID, bloom_config = bloom)
+                                             fenics_bc_id = fenics_bc_id, inner_stl = inner_path, material = material, temperature = temperature, 
+                                             options = options, global_ID = obj_global_ID, bloom_config = bloom, enclosure=enclosure, alpha=alpha)
 
                 if object_type == 'Joint':
                     object_path = path+[s for s in value if "name=" in s.lower()][0].split("=")[1]
@@ -998,7 +1008,9 @@ def read_geometry(configParser, options):
                         bloom = [False, 0, 0, 0]              
 
                     objects.insert_component(filename = object_path, file_type = object_type, inner_stl = inner_path,
-                                             trigger_type = trigger_type, trigger_value = float(trigger_value), fenics_bc_id = fenics_bc_id, material = material, temperature = temperature, options = options, global_ID = obj_global_ID, bloom_config = bloom) 
+                                             trigger_type = trigger_type, trigger_value = float(trigger_value), 
+                                             fenics_bc_id = fenics_bc_id, material = material, temperature = temperature, 
+                                             options = options, global_ID = obj_global_ID, bloom_config = bloom, alpha=alpha) 
 
 
                 print('bloom:', bloom)
@@ -1068,6 +1080,7 @@ def read_config_file(configParser, postprocess = "", emissions = ""):
     options.dynamic_plots  = get_config_value(configParser, False, 'Options', 'Plot', 'boolean')
     options.time_fidelity = get_config_value(configParser, options.time_fidelity, 'Options', 'Time_fidelity','float')
     options.write_dense_solutions = get_config_value(configParser, False, 'Options','Dense_solutions', 'boolean' )
+    options.postproc_in_loop = get_config_value(configParser, None, 'Options', 'Postprocess_in_loop','str')
     options.time_counter   = 0
 
 

--- a/Configuration/configuration.py
+++ b/Configuration/configuration.py
@@ -1047,7 +1047,7 @@ def read_config_file(configParser, postprocess = "", emissions = ""):
     options.dynamics.ignore_mach = get_config_value(configParser, 0.0, 'Time','Debug_mach_cull','float')
     options.dynamics.ignore_mass = get_config_value(configParser, 0.0, 'Time','Debug_mass_cull','float')
     options.dynamics.ignore_obj  = get_config_value(configParser, '','Time','Debug_obj_cull', 'str').split(',')
-    
+    options.dynamics.ignore_obj = [ignore.strip() for ignore in options.dynamics.ignore_obj]
     #Read Thermal options
     options.thermal.ablation       = get_config_value(configParser, False, 'Thermal', 'Ablation', 'boolean')
     if options.thermal.ablation:

--- a/Dynamics/collision.py
+++ b/Dynamics/collision.py
@@ -341,6 +341,14 @@ def collision_physics(titan, options):
 		titan.assembly[i2].pitch_vel = _w2[1] 
 		titan.assembly[i2].yaw_vel   = _w2[2]
 
+		if hasattr(titan.assembly[i1], 'state_vector'):
+			titan.assembly[i1].state_vector[3:6] = _v1
+			titan.assembly[i1].state_vector[10:13] = _w1
+		
+		if hasattr(titan.assembly[i2], 'state_vector'):
+			titan.assembly[i2].state_vector[3:6] = _v2
+			titan.assembly[i2].state_vector[10:13] = _w2
+
 
 def collision_physics_simultaneous(titan, options):
 	#Can be improved for speed

--- a/Dynamics/propagation.py
+++ b/Dynamics/propagation.py
@@ -66,7 +66,6 @@ def propagate(titan, options):
     # Writes the output data
     output.write_output_data(titan = titan, options = options)
     if options.time_fidelity>0.0: write_dense_output(titan, options)
-        
     # Communicate new vectors to assemblies
     for i_assem, _assembly in enumerate(titan.assembly):  
         update_dynamic_attributes(_assembly,new_state_vectors[i_assem],options)
@@ -495,13 +494,9 @@ def explicit_rk_adapt_wrapper(algorithm, state_vectors,state_vectors_prior,deriv
     else: 
         print('Propagator concluded with status {} ({} function evaluations)'.format(titan.rk_adapt.status,titan.rk_adapt.nfev))
         titan.end_trigger = True
-    
-    # if options.time_fidelity>0.0:
-    #     write_dense_output(titan, options)
+
     titan.delta_t = titan.rk_adapt.step_size
     return np.reshape(titan.rk_adapt.y,[-1,13]), None
-
-
 
 def proj_area_adapt_wrapper(N, state_vectors,state_vectors_prior,derivatives_prior,dt,titan,options):
     if titan.post_event_iter==0:

--- a/Dynamics/propagation.py
+++ b/Dynamics/propagation.py
@@ -65,6 +65,8 @@ def propagate(titan, options):
             _assembly.unmodded_angles  = np.array([getattr(_assembly,angle) for angle in angle_names])
     # Writes the output data
     output.write_output_data(titan = titan, options = options)
+    if options.time_fidelity>0.0: write_dense_output(titan, options)
+        
     # Communicate new vectors to assemblies
     for i_assem, _assembly in enumerate(titan.assembly):  
         update_dynamic_attributes(_assembly,new_state_vectors[i_assem],options)
@@ -137,7 +139,7 @@ def state_equation(titan,options,time,state_vectors):
     if reshape_flat: d_dt_state_vectors = np.array(d_dt_state_vectors).flatten()
     return d_dt_state_vectors, aero_states
 
-def update_dynamic_attributes(assembly,state_vector,options, force=False):
+def update_dynamic_attributes(assembly,state_vector,options, force=False, return_output_array=False):
     # This function takes an ECEF/BODY state vector and applies it to all the necessary attributes of a TITAN assembly
     # This ensures the new dynamics code plays nicely with other parts of TITAN.
 
@@ -190,7 +192,49 @@ def update_dynamic_attributes(assembly,state_vector,options, force=False):
 
         assembly.aoa = np.arctan2(Vz_B,Vx_B)
         assembly.slip = np.arcsin(Vy_B/np.sqrt(Vx_B**2 + Vy_B**2 +  Vz_B**2))
+    # if return_output_array: return np.array([assembly.id,assembly.mass,assembly.trajectory.altitude,assembly.distance_travelled,
+    #                                          assembly.trajectory.velocity,assembly.trajectory.gamma*180/np.pi,assembly.trajectory.chi*180/np.pi,
+    #                                          assembly.trajectory.latitude*180/np.pi,assembly.trajectory.longitude*180/np.pi,
+    #                                          assembly.aoa*180/np.pi,assembly.slip*180/np.pi,
+    #                                          assembly.position[0],assembly.position[1],assembly.position[2],
+    #                                          assembly.velocity[0],assembly.velocity[1],assembly.velocity[2],
+    #                                          assembly.COG[0],assembly.COG[1],assembly.COG[2],
+    #                                          assembly.body_force.force[0],assembly.body_force.force[1],assembly.body_force.force[2],
+    #                                          assembly.body_force.moment[0],assembly.body_force.moment[1],assembly.body_force.moment[2],
+    #                                          assembly.wind_force.lift,assembly.wind_force.drag,assembly.wind_force.crosswind,
+    #                                          assembly.mass,assembly.inertia[0,0],assembly.inertia[0,1],assembly.inertia[0,2],
+    #                                          assembly.inertia[1,1],assembly.inertia[1,2],assembly.inertia[2,2],
+    #                                          assembly.roll*180/np.pi,assembly.pitch*180/np.pi,assembly.yaw*180/np.pi,
+    #                                          assembly.unmodded_angles[0]*180/np.pi,assembly.unmodded_angles[1]*180/np.pi,assembly.unmodded_angles[2]*180/np.pi, 
+    #                                          assembly.roll_vel*180/np.pi,assembly.pitch_vel*180/np.pi,assembly.yaw_vel*180/np.pi,
+    #                                          np.linalg.norm([assembly.roll_vel,assembly.pitch_vel,assembly.yaw_vel])*180/np.pi, 
+    #                                          assembly.quaternion[3],assembly.quaternion[0],assembly.quaternion[1],assembly.quaternion[2],
+    #                                          assembly.quaternion_prev[3],assembly.quaternion_prev[0],assembly.quaternion_prev[1],assembly.quaternion_prev[2],
+    #                                          assembly.freestream.mach,assembly.freestream.sound,assembly.freestream.density,assembly.freestream.temperature,
+    #                                          assembly.freestream.pressure, assembly.freestream.gamma, 
+    #                                          np.sum(assembly.aerothermo.heatflux*assembly.mesh.facet_area),max(assembly.aerothermo.heatflux),
+    #                                          max(assembly.aerothermo.temperature),assembly.freestream.knudsen]
 
+    #     for specie, pct in zip(assembly.freestream.species_index, assembly.freestream.percent_mass[0]) :
+    #         df[specie+"_mass_pct"] = [pct]
+
+    #     #Stagnation properties
+    #     try:
+    #         df['Qstag'] = [assembly.aerothermo.qconvstag]
+    #         df['Qradstag'] = [assembly.aerothermo.qradstag]
+    #     except:
+    #         pass
+
+    #     try:
+    #         df['Pstag'] = [assembly.freestream.P1_s]
+    #         df['Tstag'] = [assembly.freestream.T1_s]
+    #         df['Rhostag'] = [assembly.freestream.rho_s]
+    #     except:
+    #         pass
+
+    #     #Reference Dimensionsal constants
+    #     df["Aref"] = [assembly.Aref]
+    #     df["Lref"] = [assembly.Lref]])
     return assembly
 
 def construct_state_vector(assembly):
@@ -253,6 +297,22 @@ def append_derivatives(titan,options,new_derivs):
         if n_derivs==options.dynamics.n_derivs_to_hold and len(_assembly.derivs_prior)>0:
             _assembly.derivs_prior.pop(0)
         _assembly.derivs_prior.append(new_derivs[i_assem])
+
+def write_dense_output(titan, options):
+    ## This function writes outputs of the previous iteration as a dense output as specified by the time fidelity option
+    options.last_output_time = titan.time
+    #prior_states = [_assembly.state_vector for _assembly in titan.assembly]
+    interpolant = titan.rk_adapt.dense_output()
+    times = np.arange(options.last_output_time+options.time_fidelity,options.last_output_time+titan.rk_adapt.step_size, options.time_fidelity)
+    for time in times:
+        if len(titan.assembly)>1:
+            print('Whup!')
+        state_vectors = np.reshape(interpolant(time),[-1,13])
+        for _assembly, state in zip(titan.assembly,state_vectors): update_dynamic_attributes(_assembly, state, options)
+        titan.time = time
+        output.write_output_data(titan, options, just_smooth=True)
+    titan.time = options.last_output_time
+    for _assembly, state in zip(titan.assembly,np.reshape(titan.rk_adapt.y,[-1,13])): update_dynamic_attributes(_assembly, state, options)
 
 def get_integrator_func(options, choice):
 
@@ -412,30 +472,36 @@ def explicit_rk_adapt_wrapper(algorithm, state_vectors,state_vectors_prior,deriv
     elif not np.shape(titan.rk_params['state'])==np.shape(np.array(state_vectors).flatten()): recompute_params = True
     else: recompute_params = False
     if recompute_params: 
-        if titan.time>0: titan.time-=dt
+        if titan.post_event_iter>0: titan.time-=dt
         titan.rk_params = {'time'    : titan.time, 
                            'state'   : np.array(state_vectors).flatten(),
                            't_end'   : options.dynamics.t_end, 
-                           't_first' : options.dynamics.dt_initial,  # Prefer a small initial timestep to combat discontinuities at fragmentation
-                           't_max'   : options.dynamics.dt_max}
+                           't_first' : options.dynamics.dt_initial,  # Prefer a small initial timestep to combat discontinuities
+                           't_max'   : options.dynamics.dt_max,
+                           'dense'   : options.time_fidelity>0}
 
     if not hasattr(titan, 'rk_fun')   or recompute_params: 
         def rk_wrapper(titan,options,time,vector): return state_equation(titan,options,time,vector)[0]
         titan.rk_fun=partial(rk_wrapper,titan,options)
+
     if not hasattr(titan, 'rk_adapt') or recompute_params: titan.rk_adapt=algorithm(fun=titan.rk_fun,
                                                                                     t0=titan.rk_params['t_first'],
                                                                                     y0=titan.rk_params['state'],
                                                                                     t_bound=titan.rk_params['t_end'],
                                                                                     first_step=titan.rk_params['t_first'],
                                                                                     max_step=titan.rk_params['t_max'])
-
     if titan.rk_adapt.status == 'running':
         titan.rk_adapt.step()
     else: 
         print('Propagator concluded with status {} ({} function evaluations)'.format(titan.rk_adapt.status,titan.rk_adapt.nfev))
         titan.end_trigger = True
+    
+    # if options.time_fidelity>0.0:
+    #     write_dense_output(titan, options)
     titan.delta_t = titan.rk_adapt.step_size
     return np.reshape(titan.rk_adapt.y,[-1,13]), None
+
+
 
 def proj_area_adapt_wrapper(N, state_vectors,state_vectors_prior,derivatives_prior,dt,titan,options):
     if titan.post_event_iter==0:

--- a/Dynamics/propagation.py
+++ b/Dynamics/propagation.py
@@ -13,7 +13,6 @@ from functools import partial
 from Output import output
 from warnings import warn
 from copy import copy, deepcopy
-import concurrent.futures, psutil
 ## Current implented integrators (define in cfg under [Time] as Time_integration='')...
 
 ## Constant time-step methods  
@@ -672,3 +671,11 @@ def quaternion_conjugate(q): return np.array([-q[0],-q[1],-q[2],q[3]])
 def quaternion_normalize(q):
     norm = np.linalg.norm(q)
     return q/norm
+
+def quaternion_to_matrix(q):
+    return np.array([
+        [1 - 2 * (q[1]**2 + q[2]**2),     2 * (q[0] * q[1] - q[3] * q[2]), 2 * (q[0] * q[2] + q[3] * q[1]), 0],
+        [2 * (q[0] * q[1] + q[3] * q[2]), 1 - 2 * (q[0]**2 + q[2]**2),     2 * (q[1] * q[2] - q[3] * q[0]), 0],
+        [2 * (q[0] * q[2] - q[3] * q[1]), 2 * (q[1] * q[2] + q[3] * q[0]), 1 - 2 * (q[0]**2 + q[1]**2),     0],
+        [0,                               0,                               0,                               1]
+    ])

--- a/Dynamics/propagation.py
+++ b/Dynamics/propagation.py
@@ -1,8 +1,10 @@
+import os
 from Dynamics import dynamics, frames, collision
 from Aerothermo import aerothermo
 from Forces import forces
 import pymap3d
 import numpy as np
+import pandas as pd
 from scipy.spatial.transform import Rotation as Rot
 from scipy.special import erf
 from scipy import integrate
@@ -10,8 +12,8 @@ from scipy.stats import uniform_direction
 from functools import partial
 from Output import output
 from warnings import warn
-from copy import copy
-
+from copy import copy, deepcopy
+import concurrent.futures, psutil
 ## Current implented integrators (define in cfg under [Time] as Time_integration='')...
 
 ## Constant time-step methods  
@@ -54,6 +56,10 @@ def propagate(titan, options):
         #Check collision for future time intervals with respect to current time-step velocity
         __, time_step = collision.check_collision(titan, options, time_step)
     
+    surface_solutions = output.create_surface_solution(titan,options)
+    for _assembly, sol in zip(titan.assembly, surface_solutions): 
+        _assembly.prev_surf_data = deepcopy(sol.cell_data)
+        # if hasattr(_assembly, 'surf_data'): _assembly.prev_surf_data = deepcopy(_assembly.surf_data)
     # Propagate according to propagator function...
     new_state_vectors, new_derivs = options.dynamics.prop_func(current_state_vectors,state_vectors_prior,derivatives_prior,time_step,titan,options)
     # Update prior derivatives
@@ -191,49 +197,20 @@ def update_dynamic_attributes(assembly,state_vector,options, force=False, return
 
         assembly.aoa = np.arctan2(Vz_B,Vx_B)
         assembly.slip = np.arcsin(Vy_B/np.sqrt(Vx_B**2 + Vy_B**2 +  Vz_B**2))
-    # if return_output_array: return np.array([assembly.id,assembly.mass,assembly.trajectory.altitude,assembly.distance_travelled,
-    #                                          assembly.trajectory.velocity,assembly.trajectory.gamma*180/np.pi,assembly.trajectory.chi*180/np.pi,
-    #                                          assembly.trajectory.latitude*180/np.pi,assembly.trajectory.longitude*180/np.pi,
-    #                                          assembly.aoa*180/np.pi,assembly.slip*180/np.pi,
-    #                                          assembly.position[0],assembly.position[1],assembly.position[2],
-    #                                          assembly.velocity[0],assembly.velocity[1],assembly.velocity[2],
-    #                                          assembly.COG[0],assembly.COG[1],assembly.COG[2],
-    #                                          assembly.body_force.force[0],assembly.body_force.force[1],assembly.body_force.force[2],
-    #                                          assembly.body_force.moment[0],assembly.body_force.moment[1],assembly.body_force.moment[2],
-    #                                          assembly.wind_force.lift,assembly.wind_force.drag,assembly.wind_force.crosswind,
-    #                                          assembly.mass,assembly.inertia[0,0],assembly.inertia[0,1],assembly.inertia[0,2],
-    #                                          assembly.inertia[1,1],assembly.inertia[1,2],assembly.inertia[2,2],
-    #                                          assembly.roll*180/np.pi,assembly.pitch*180/np.pi,assembly.yaw*180/np.pi,
-    #                                          assembly.unmodded_angles[0]*180/np.pi,assembly.unmodded_angles[1]*180/np.pi,assembly.unmodded_angles[2]*180/np.pi, 
-    #                                          assembly.roll_vel*180/np.pi,assembly.pitch_vel*180/np.pi,assembly.yaw_vel*180/np.pi,
-    #                                          np.linalg.norm([assembly.roll_vel,assembly.pitch_vel,assembly.yaw_vel])*180/np.pi, 
-    #                                          assembly.quaternion[3],assembly.quaternion[0],assembly.quaternion[1],assembly.quaternion[2],
-    #                                          assembly.quaternion_prev[3],assembly.quaternion_prev[0],assembly.quaternion_prev[1],assembly.quaternion_prev[2],
-    #                                          assembly.freestream.mach,assembly.freestream.sound,assembly.freestream.density,assembly.freestream.temperature,
-    #                                          assembly.freestream.pressure, assembly.freestream.gamma, 
-    #                                          np.sum(assembly.aerothermo.heatflux*assembly.mesh.facet_area),max(assembly.aerothermo.heatflux),
-    #                                          max(assembly.aerothermo.temperature),assembly.freestream.knudsen]
-
-    #     for specie, pct in zip(assembly.freestream.species_index, assembly.freestream.percent_mass[0]) :
-    #         df[specie+"_mass_pct"] = [pct]
-
-    #     #Stagnation properties
-    #     try:
-    #         df['Qstag'] = [assembly.aerothermo.qconvstag]
-    #         df['Qradstag'] = [assembly.aerothermo.qradstag]
-    #     except:
-    #         pass
-
-    #     try:
-    #         df['Pstag'] = [assembly.freestream.P1_s]
-    #         df['Tstag'] = [assembly.freestream.T1_s]
-    #         df['Rhostag'] = [assembly.freestream.rho_s]
-    #     except:
-    #         pass
-
-    #     #Reference Dimensionsal constants
-    #     df["Aref"] = [assembly.Aref]
-    #     df["Lref"] = [assembly.Lref]])
+        angular_momentum = assembly.inertia @ np.array([assembly.roll_vel,assembly.pitch_vel,assembly.yaw_vel] )
+    if return_output_array: return np.array([assembly.id,assembly.mass,assembly.trajectory.altitude,
+                                             assembly.trajectory.velocity,assembly.trajectory.gamma*180/np.pi,assembly.trajectory.chi*180/np.pi,
+                                             assembly.trajectory.latitude*180/np.pi,assembly.trajectory.longitude*180/np.pi,
+                                             assembly.aoa*180/np.pi,assembly.slip*180/np.pi,
+                                             assembly.position[0],assembly.position[1],assembly.position[2],
+                                             assembly.velocity[0],assembly.velocity[1],assembly.velocity[2],
+                                             assembly.COG[0],assembly.COG[1],assembly.COG[2],
+                                             assembly.roll*180/np.pi,assembly.pitch*180/np.pi,assembly.yaw*180/np.pi,
+                                             assembly.unmodded_angles[0]*180/np.pi,assembly.unmodded_angles[1]*180/np.pi,assembly.unmodded_angles[2]*180/np.pi, 
+                                             assembly.roll_vel*180/np.pi,assembly.pitch_vel*180/np.pi,assembly.yaw_vel*180/np.pi,
+                                             np.linalg.norm([assembly.roll_vel,assembly.pitch_vel,assembly.yaw_vel])*180/np.pi,
+                                             angular_momentum[0], angular_momentum[1], angular_momentum[2], np.linalg.norm(angular_momentum),
+                                             assembly.quaternion[3],assembly.quaternion[0],assembly.quaternion[1],assembly.quaternion[2]])
     return assembly
 
 def construct_state_vector(assembly):
@@ -299,19 +276,70 @@ def append_derivatives(titan,options,new_derivs):
 
 def write_dense_output(titan, options):
     ## This function writes outputs of the previous iteration as a dense output as specified by the time fidelity option
-    options.last_output_time = titan.time
-    #prior_states = [_assembly.state_vector for _assembly in titan.assembly]
-    interpolant = titan.rk_adapt.dense_output()
-    times = np.arange(options.last_output_time+options.time_fidelity,options.last_output_time+titan.rk_adapt.step_size, options.time_fidelity)
-    for time in times:
-        if len(titan.assembly)>1:
-            print('Whup!')
-        state_vectors = np.reshape(interpolant(time),[-1,13])
-        for _assembly, state in zip(titan.assembly,state_vectors): update_dynamic_attributes(_assembly, state, options)
-        titan.time = time
-        output.write_output_data(titan, options, just_smooth=True)
-    titan.time = options.last_output_time
-    for _assembly, state in zip(titan.assembly,np.reshape(titan.rk_adapt.y,[-1,13])): update_dynamic_attributes(_assembly, state, options)
+    true_time = titan.time
+    times = np.arange(titan.last_output_time+options.time_fidelity,true_time+titan.rk_adapt.step_size, options.time_fidelity)
+    ## Some sanity checks
+    times = times[np.where(times>true_time)]
+    times = times[np.where(times<true_time+titan.rk_adapt.step_size)]
+    if options.write_dense_solutions: surface_solutions = output.create_surface_solution(titan,options)
+    if len(times)>0:
+        prior_states = copy(np.reshape(titan.rk_adapt.y,[-1,13]))
+        interpolant = titan.rk_adapt.dense_output()
+        times += interpolant.t_min - true_time
+        n_assem = len(titan.assembly)
+        data_array = np.zeros([len(times)*n_assem,38])
+        
+        # Some more sanity checks
+        if not np.min(times)>=interpolant.t_min:
+            warn('Extrapolating interpolant backwards! Past valid t={} to t={}'.format(interpolant.t_min,np.min(times)))
+        if not np.max(times)<=interpolant.t_max:
+            warn('Extrapolating interpolant forwards! Past valid t={} to t={}'.format(interpolant.t_max,np.max(times)))
+
+        timestep_func = partial(generate_dense_timestep,titan.assembly,options,interpolant)
+
+        for i_time, time in enumerate(times):
+            timestep_data, overwrite = timestep_func(time)
+            data_array[i_time*n_assem:i_time*n_assem+n_assem,:] = timestep_data
+            if len(overwrite)>0 and options.write_dense_solutions: 
+                output.update_surface_solution(titan,options,surface_solutions,overwrite)
+            if options.write_dense_solutions: 
+                output.write_surface_solution(options,surface_solutions,[_assembly.id for _assembly in titan.assembly],
+                                          np.round(time-interpolant.t_min + true_time,6),folder='Dense_surface_solution')
+            
+        for _assembly, state in zip(titan.assembly,prior_states): update_dynamic_attributes(_assembly, state, options)
+
+        header = [['Time', 'Assembly_ID','Mass','Altitude','Velocity',
+                'FlightPathAngle','HeadingAngle','Latitude','Longitude',
+                'AngleAttack','AngleSideslip','ECEF_X','ECEF_Y','ECEF_Z',
+                'ECEF_vU','ECEF_vV','ECEF_vW','BODY_COM_X','BODY_COM_Y',
+                'BODY_COM_Z','Roll','Pitch','Yaw','distRoll','distPitch',
+                'distYaw','velRoll','velPitch','velYaw','magnitudeOmega',
+                'angularMomentum_x','angularMomentum_y','angularMomentum_z',
+                'magnitudeAngularMomentum','Quat_w','Quat_x','Quat_y','Quat_z']]
+        data_array[:,0] += true_time - interpolant.t_min
+        data_array[:,0] = np.round(data_array[:,0],6)
+        df = pd.DataFrame(data_array,columns=header)
+        header = True if not os.path.exists(options.output_folder + '/Data/'+ 'data_smooth.csv') else False
+        titan.last_output_time=np.max(times)-interpolant.t_min + true_time
+        df.to_csv(options.output_folder + '/Data/'+ 'data_smooth.csv',header=header,mode='a',index=False)
+
+def generate_dense_timestep(assemblies, options, interpolant, time):
+    
+    n_assem = len(assemblies)
+    state_vectors = np.reshape(interpolant(time),[-1,13])
+    data_array = np.zeros([n_assem,38])
+    data_array[:,0] = np.array([time for _ in range(n_assem)])
+    overwrite_solutions = []
+    for i_assem, _assembly in enumerate(assemblies): 
+        data_array[i_assem,1:] = update_dynamic_attributes(_assembly, state_vectors[i_assem], options, return_output_array=True)
+        if hasattr(_assembly,'prev_surf_data'):
+            overwrite_data = copy(_assembly.prev_surf_data)
+            lerp_value = (time-interpolant.t_min)/(interpolant.t_max - interpolant.t_min)
+            for field in overwrite_data.keys():
+                overwrite_data[field][:] = (1-lerp_value)*np.array(_assembly.prev_surf_data[field][:]) + lerp_value * getattr(_assembly.aerothermo,field)
+            overwrite_solutions.append(overwrite_data)
+    return data_array, overwrite_solutions
+    
 
 def get_integrator_func(options, choice):
 

--- a/Dynamics/propagation.py
+++ b/Dynamics/propagation.py
@@ -35,11 +35,9 @@ def propagate(titan, options):
     #  a 13-D state vector of form [Position(x/y/z),Velocity(u/v/w),Quaternion(w/i/j/k),Angular velocity(roll_vel,pitch_vel,yaw_vel)]
     #  a propagator specified by options.dynamics.propagator
 
-    #TODO: Manage collision handling properly
     if options.collision.flag and len(titan.assembly)>1:
         flag_collision, __ = collision.check_collision(titan, options, 0)
         if flag_collision: collision.collision_physics(titan, options)
-        #if flag_collision: collision.collision_physics_simultaneous(titan, options)
 
     # If we go to switch.py or su2.py, Because we call deepcopy() function, we need to rebuild
     #the collision mesh
@@ -50,8 +48,7 @@ def propagate(titan, options):
     # Retrieve state vectors from each assembly object...
     current_state_vectors, state_vectors_prior, derivatives_prior = collect_state_vectors(titan, options)
 
-    ## NB: Highly unsure if I've correctly applied this collision implementation, see earlier todo
-    time_step = options.dynamics.time_step
+    time_step = options.dynamics.time_step if not hasattr(titan,'rk_adapt') else options.dynamics.dt_max
     if options.collision.flag and len(titan.assembly)>1:
         #Check collision for future time intervals with respect to current time-step velocity
         __, time_step = collision.check_collision(titan, options, time_step)
@@ -59,7 +56,7 @@ def propagate(titan, options):
     surface_solutions = output.create_surface_solution(titan,options)
     for _assembly, sol in zip(titan.assembly, surface_solutions): 
         _assembly.prev_surf_data = deepcopy(sol.cell_data)
-        # if hasattr(_assembly, 'surf_data'): _assembly.prev_surf_data = deepcopy(_assembly.surf_data)
+
     # Propagate according to propagator function...
     new_state_vectors, new_derivs = options.dynamics.prop_func(current_state_vectors,state_vectors_prior,derivatives_prior,time_step,titan,options)
     # Update prior derivatives
@@ -518,6 +515,7 @@ def explicit_rk_adapt_wrapper(algorithm, state_vectors,state_vectors_prior,deriv
                                                                                     first_step=titan.rk_params['t_first'],
                                                                                     max_step=titan.rk_params['t_max'])
     if titan.rk_adapt.status == 'running':
+        titan.rk_adapt.max_step = dt
         titan.rk_adapt.step()
     else: 
         print('Propagator concluded with status {} ({} function evaluations)'.format(titan.rk_adapt.status,titan.rk_adapt.nfev))

--- a/Dynamics/propagation.py
+++ b/Dynamics/propagation.py
@@ -93,9 +93,11 @@ def state_equation(titan,options,time,state_vectors):
         state_vectors = np.reshape(state_vectors,[-1,13])
 
     # First we communicate the state vector to assembly attributes
-    if titan.iter>0:
-        for _assembly, state_vector in zip(titan.assembly,state_vectors):
-            update_dynamic_attributes(_assembly,state_vector,options)
+    # if titan.iter>0:
+    unaltered_states = []
+    for _assembly, state_vector in zip(titan.assembly,state_vectors):
+        unaltered_states.append(_assembly.state_vector)
+        update_dynamic_attributes(_assembly,state_vector,options)
     
     # Then business as usual for computing forces...
     
@@ -127,15 +129,19 @@ def state_equation(titan,options,time,state_vectors):
                                    angularDerivatives.ddroll,
                                    angularDerivatives.ddpitch,
                                    angularDerivatives.ddyaw,])
-        
+    
+    # Finally reset the Dynamic state to be controlled by the chosen propagator
+    for _assembly, return_state in zip(titan.assembly, unaltered_states):
+        update_dynamic_attributes(_assembly,return_state,options,force=True)
+
     if reshape_flat: d_dt_state_vectors = np.array(d_dt_state_vectors).flatten()
     return d_dt_state_vectors, aero_states
 
-def update_dynamic_attributes(assembly,state_vector,options):
+def update_dynamic_attributes(assembly,state_vector,options, force=False):
     # This function takes an ECEF/BODY state vector and applies it to all the necessary attributes of a TITAN assembly
     # This ensures the new dynamics code plays nicely with other parts of TITAN.
 
-    if not np.array_equal(assembly.state_vector,state_vector): # Only need to update if state vector is different
+    if not np.array_equal(assembly.state_vector,state_vector) or force: # Only need to update if state vector is different
         # Update ECEF state...
         assembly.position[0] = state_vector[0]
         assembly.position[1] = state_vector[1]
@@ -504,7 +510,6 @@ def proj_area_adapt_wrapper(N, state_vectors,state_vectors_prior,derivatives_pri
 
 
 def explicit_rk_N(N,state_vectors,state_vectors_prior,derivatives_prior,dt,titan,options):
-    new_state_vectors = []
     k_n = []
     for i_k in range(RK_N_actual[str(N)]):
         k_state_vectors = np.array(state_vectors)

--- a/Fragmentation/fragmentation.py
+++ b/Fragmentation/fragmentation.py
@@ -211,7 +211,6 @@ def demise_components(titan, i, joints_id, options):
         titan.assembly[-1].aoa = titan.assembly[i].aoa
         titan.assembly[-1].slip = titan.assembly[i].slip
 
-        titan.post_event_iter = 0
         from Dynamics.propagation import construct_state_vector
         construct_state_vector(titan.assembly[-1])
         titan.assembly[-1].unmodded_angles = titan.assembly[i].unmodded_angles
@@ -617,6 +616,8 @@ def fragmentation(titan, options):
     titan.assembly = np.delete(titan.assembly,assembly_id).tolist()
 
     if fragmentation_flag:
+        titan.post_event_iter = 0
+        titan.event_time = titan.time
         for assembly in titan.assembly:
             assembly.rearrange_ids()
 

--- a/Fragmentation/fragmentation.py
+++ b/Fragmentation/fragmentation.py
@@ -575,7 +575,7 @@ def fragmentation(titan, options):
                     con_delete = []
 
                     for index, con in enumerate(titan.assembly[it].connectivity):
-                        if con[2] == 0:
+                        if con[2] == 0 and obj.id in con:
                             con_delete.append(index)
                     
                     titan.assembly[it].connectivity = np.delete(titan.assembly[it].connectivity, con_delete, axis = 0)

--- a/Geometry/assembly.py
+++ b/Geometry/assembly.py
@@ -589,11 +589,6 @@ class Assembly():
         self.mesh.vol_mass  = vol*density
         self.mass = np.sum(self.mesh.vol_mass)
 
-        print('density:', density[0])
-
-        print('volume:', np.sum(vol))
-
-        print('mass:', self.mass)
 
         #Computes the Center of Mass
         if self.mass <= 0:

--- a/Geometry/assembly.py
+++ b/Geometry/assembly.py
@@ -20,6 +20,7 @@
 from Geometry import mesh as Mesh
 from Geometry import gmsh_api as GMSH
 from Geometry.tetra import inertia_tetra, vol_tetra
+from Geometry.enclosure import build_enclosure_AABB, build_enclosure_num
 import numpy as np
 from copy import deepcopy
 import subprocess
@@ -325,6 +326,7 @@ class Aerothermo():
         self.Te = np.zeros((n_points))
         self.rhoe = np.zeros((n_points))
         self.ue = np.zeros((n_points))
+        self.debug_alpha = np.zeros((n_points))
 
         #Air-5 species + material element
         self.nSpecies = 6
@@ -470,6 +472,7 @@ class Assembly():
         #Initialize surface temperature of the assembly
         for obj in self.objects:
             self.aerothermo.temperature[obj.facet_index] = obj.temperature
+            self.aerothermo.debug_alpha[obj.facet_index] = obj.debug_alpha
 
         self.collision = None
 
@@ -519,6 +522,9 @@ class Assembly():
 
         self.angle_blackbody = np.zeros(len(self.mesh.facets))
         self.angle_atomic    = np.zeros(len(self.mesh.facets))
+
+        self.enclosure_AABB = build_enclosure_AABB(self)
+        self.enclosure_component_num = build_enclosure_num(self)
 
 
     def generate_inner_domain(self, write = False, output_folder = '', output_filename = '', bc_ids = []):

--- a/Geometry/component.py
+++ b/Geometry/component.py
@@ -29,11 +29,15 @@ class Component_list():
         self.object = []
         self.id = 1
         
-    def insert_component(self,filename, file_type, inner_stl = '', id = 0, binary = True, trigger_type = 'Indestructible', trigger_value = 0,fenics_bc_id = -1, material = 'Unittest', temperature = 300, options = None, global_ID = 0, bloom_config = [False, 0, 0, 0]):
+    def insert_component(self,filename, file_type, inner_stl = '', id = 0, binary = True, trigger_type = 'Indestructible', 
+                         trigger_value = 0,fenics_bc_id = -1, material = 'Unittest', temperature = 300, options = None, 
+                         global_ID = 0, bloom_config = [False, 0, 0, 0], enclosure=0, alpha = 1.0):
 
         self.object.append(Component(filename, file_type, inner_stl = inner_stl, id = self.id, 
                            binary = binary, temperature = temperature, trigger_type = trigger_type,
-                           trigger_value = trigger_value, fenics_bc_id = fenics_bc_id, material = material, options = options, global_ID = global_ID, bloom_config = bloom_config))
+                           trigger_value = trigger_value, fenics_bc_id = fenics_bc_id, material = material, 
+                           options = options, global_ID = global_ID, bloom_config = bloom_config, 
+                           enclosure=enclosure, alpha=alpha))
         self.id += 1
 
 class Component():
@@ -44,7 +48,8 @@ class Component():
     
     def __init__(self,filename, file_type, inner_stl = '', id = 0, binary = True, temperature = 300,
                  trigger_type = 'Indestructible', trigger_value = 0, fenics_bc_id = -1, material = 'Unittest',
-                 v0 = [], v1 = [], v2 = [], parent_id = None, parent_part = None, options = None, global_ID = 0, bloom_config = [False, 0, 0, 0]):
+                 v0 = [], v1 = [], v2 = [], parent_id = None, parent_part = None, options = None, global_ID = 0, 
+                 bloom_config = [False, 0, 0, 0], enclosure = 0, alpha = 1.0):
 
         print("Generating Body: ", filename)
         
@@ -131,6 +136,9 @@ class Component():
             self.bloom = bloom(bloom_config)
 
         self.density_ratio = 1
+
+        self.enclosure = enclosure
+        self.debug_alpha = alpha
 
     def compute_mass_properties(self, coords, elements, density):
         """

--- a/Geometry/enclosure.py
+++ b/Geometry/enclosure.py
@@ -1,0 +1,142 @@
+import numpy as np
+from scipy.spatial.transform import Rotation as Rot
+import os
+from meshio import Mesh
+# This function returns a boolean decision of whether to do a raytracing calc on the assembly
+# based upon its enclosure state, which is equivalent to ~is_enclosed 
+def check_enclosure(assembly_list,options, assembly_index,debug_iter=0):
+    # Assembly of interest
+    do_raytrace = False
+    AoI = assembly_list[assembly_index]
+    enclosure_list = np.array([component.enclosure for component in AoI.objects])
+    # If any part of the assembly is unenclosed we must simulate it
+    if np.any(enclosure_list>=0): return True
+    enclosures = np.unique(enclosure_list)
+    for enclosed in enclosures:
+        found_assembly = False
+        for i_assem, _assembly in enumerate(assembly_list):
+            if not i_assem==assembly_index:
+                if -1*enclosed in _assembly.enclosure_AABB.keys():
+                    # If enclosure is split across multiple assemblies the enclosed is exposed  to the airstream
+                    if found_assembly: 
+                        print('Enclosure fragmented! Breaking connection')
+                        for component in AoI.objects: component.enclosure = 0
+                        return True
+                    else: found_assembly = True
+                    enclosure_objs = np.array([component.enclosure for component in _assembly.objects])
+                    n_objs = len(np.where(enclosure_objs==-1*enclosed)[0])
+                    # If the enclosure has been broken the enclosed is exposed to the airstream
+                    if n_objs<_assembly.enclosure_component_num[-1*enclosed]: return True
+                    # Final check is if enclosed object has left enclosure AABB
+                    #enclosure_AABB = transform_AABB(_assembly.enclosure_AABB[-1*enclosed],_assembly.quaternion,_assembly.COG,_assembly.position,-_assembly.position)
+                    # enclosed_AABB = transform_AABB(AoI.enclosure_AABB[enclosed],AoI.quaternion,AoI.COG,AoI.position, -_assembly.position)
+                    # debug_AABB_mesh(enclosed_AABB,filename='closed_{}_{}'.format(assembly_index,debug_iter-5))
+                    # debug_AABB_mesh(enclosure_AABB,filename='closure_{}_{}'.format(i_assem,debug_iter-5))
+                    do_raytrace = enclosure_mesh_check(AoI.mesh,AoI.COG,_assembly.enclosure_AABB[-1*enclosed],AoI.quaternion,_assembly.quaternion, _assembly.position-AoI.position, 
+                                         ['closed_{}_{}'.format(assembly_index,debug_iter),'closure_{}_{}'.format(i_assem,debug_iter-5)])
+    return do_raytrace
+# Build collection of Axis-Aligned Bounding Boxes (AABBs) for each enclosure id,
+# a necessary but not sufficient criterion for something being inside something else
+def build_enclosure_AABB(assembly):
+    AABB_dict = {}
+    for component in assembly.objects:
+        if not component.enclosure==0:
+            comp_AABB = [np.zeros(3),np.zeros(3),np.zeros(3)]
+            comp_AABB[0] = np.min(component.mesh.nodes-component.mesh.COG, axis=0)
+            comp_AABB[1] = np.max(component.mesh.nodes-component.mesh.COG, axis=0)
+            if not component.enclosure in AABB_dict.keys(): AABB_dict[component.enclosure] = comp_AABB                
+            else:
+                for i_ax in range(3):
+                    if comp_AABB[0][i_ax]<AABB_dict[component.enclosure][0][i_ax]: 
+                        AABB_dict[component.enclosure][0][i_ax] = comp_AABB[0][i_ax] 
+                    if comp_AABB[1][i_ax]>AABB_dict[component.enclosure][1][i_ax]: 
+                        AABB_dict[component.enclosure][1][i_ax] = comp_AABB[1][i_ax]
+    return AABB_dict
+# Need also to log the number components in an enclosure to check if enclosure is still whole
+def build_enclosure_num(assembly):
+    num = {}
+    for component in assembly.objects:
+        if component.enclosure>0:
+            if not component.enclosure in num.keys(): 
+                num[component.enclosure] = 1
+            else: num[component.enclosure]+=1
+    return num
+
+def transform_AABB(AABB, quaternion_BODY, translation_CoG, translation_ECEF, translation_DATUM):
+    from Dynamics.propagation import quaternion_to_matrix
+    output_AABB = [np.zeros(3),np.zeros(3)]
+    box_array = np.array([[AABB[0][0],AABB[0][1],AABB[0][2],1], 
+                          [AABB[0][0],AABB[0][1],AABB[1][2],1],
+                          [AABB[0][0],AABB[1][1],AABB[0][2],1],
+                          [AABB[1][0],AABB[0][1],AABB[0][2],1],
+                          [AABB[0][0],AABB[1][1],AABB[1][2],1],
+                          [AABB[1][0],AABB[0][1],AABB[1][2],1],
+                          [AABB[1][0],AABB[1][1],AABB[0][2],1],
+                          [AABB[1][0],AABB[1][1],AABB[1][2],1]])
+    mat_CoG  = np.eye(4)
+    mat_ECEF = np.eye(4)
+    mat_DATUM = np.eye(4)
+    mat_ECEF[:-1,-1] = translation_ECEF
+    mat_DATUM[:-1,-1] = translation_DATUM
+    mat_BODY = quaternion_to_matrix(quaternion_BODY)
+    transform =  mat_DATUM @ mat_ECEF @ mat_BODY# @ mat_CoG
+    transform_AABB = box_array @ transform.T
+    output_AABB[0] = np.min(transform_AABB,axis=0)[:-1]
+    output_AABB[1] = np.max(transform_AABB,axis=0)[:-1]
+    return output_AABB
+
+def debug_AABB_mesh(AABB, filename=None):
+    box_array = np.array([[AABB[0][0],AABB[0][1],AABB[0][2]], 
+                         [AABB[0][0],AABB[0][1],AABB[1][2]],
+                         [AABB[0][0],AABB[1][1],AABB[0][2]],
+                         [AABB[1][0],AABB[0][1],AABB[0][2]],
+                         [AABB[0][0],AABB[1][1],AABB[1][2]],
+                         [AABB[1][0],AABB[0][1],AABB[1][2]],
+                         [AABB[1][0],AABB[1][1],AABB[0][2]],
+                         [AABB[1][0],AABB[1][1],AABB[1][2]]])
+
+    faces = np.array([
+        # bottom (z = zmin): 0,2,3,6
+        [0,2,3], [2,6,3],
+        # top (z = zmax): 1,4,5,7
+        [1,5,4], [4,5,7],
+        # front (y = ymin): 0,1,3,5
+        [0,1,3], [1,5,3],
+        # back (y = ymax): 2,4,6,7
+        [2,6,4], [4,6,7],
+        # left (x = xmin): 0,2,1,4
+        [0,1,2], [1,4,2],
+        # right (x = xmax): 3,5,6,7
+        [3,6,5], [5,6,7],
+    ])
+    aabb_mesh = Mesh(points= box_array,cells = {"triangle": faces})
+    if not os.path.exists('./debug_AABB'): os.mkdir('./debug_AABB')
+    aabb_mesh.write('./debug_AABB/{}.stl'.format(filename))
+
+def enclosure_mesh_check(enclosed_mesh, enclosed_COG, enclosure_AABB_BODY, quat_enclosed, quat_enclosure, dist, debug_meshes=None):
+    ## Firstly must transform enclosed to enclosure body frame...
+    R_B_ECEF_closed  = np.eye(4)
+    R_ECEF_B_closure = np.eye(4)
+    translate_COG    = np.eye(4)
+    translate_dist   = np.eye(4)
+    
+    R_B_ECEF_closed[:-1,:-1]  = Rot.from_quat(quat_enclosed).as_matrix()
+    R_ECEF_B_closure[:-1,:-1] = Rot.from_quat(quat_enclosure).inv().as_matrix()
+    translate_COG[:-1,-1] = -enclosed_COG
+    translate_dist[:-1,-1] = dist
+    transform = R_ECEF_B_closure @ translate_dist @ R_B_ECEF_closed @ translate_COG
+    transformed_nodes = np.hstack([enclosed_mesh.nodes, np.ones([np.shape(enclosed_mesh.nodes)[0],1])]) @ transform.T
+
+    closed_AABB = [np.min(transformed_nodes,axis=0)[:-1],np.max(transformed_nodes,axis=0)[:-1]]
+
+    if debug_meshes is not None:
+        debug_AABB_mesh(closed_AABB,filename=debug_meshes[0])
+        debug_AABB_mesh(enclosure_AABB_BODY,filename=debug_meshes[1])
+
+    if np.any(closed_AABB[0]<enclosure_AABB_BODY[0]): 
+        print('Assembly has left enclosure!')
+        return True
+    if np.any(closed_AABB[1]>enclosure_AABB_BODY[1]): 
+        print('Assembly has left enclosure!')
+        return True
+    return False

--- a/Geometry/enclosure.py
+++ b/Geometry/enclosure.py
@@ -6,11 +6,11 @@ from meshio import Mesh
 # based upon its enclosure state, which is equivalent to ~is_enclosed 
 def check_enclosure(assembly_list,options, assembly_index,debug_iter=0):
     # Assembly of interest
-    do_raytrace = False
     AoI = assembly_list[assembly_index]
     enclosure_list = np.array([component.enclosure for component in AoI.objects])
     # If any part of the assembly is unenclosed we must simulate it
     if np.any(enclosure_list>=0): return True
+    do_raytrace = False
     enclosures = np.unique(enclosure_list)
     for enclosed in enclosures:
         found_assembly = False

--- a/Material/ATV_material.xml
+++ b/Material/ATV_material.xml
@@ -1,7 +1,7 @@
-<materialList>
+﻿<materialList>
 	<metalMaterial>
-		<name>Unittest</name>
-		<density>1000.0</density>
+		<name>ATV_JBody</name>
+		<density>0.1</density>
 		<specificHeatCapacity>
 			<values>293,877.5;313,885.5;333,893.5;353,901.5;373,909.5;393,917.5;413,925.6;433,933.6;453,941.6;473,949.6;493,957.6;513,965.6;533,973.6;553,981.6;573,989.6;593,997.6;613,1005.6;633,1013.6;653,1021.7;673,1029.7;693,1037.7;713,1045.7;733,1053.7;753,1061.7;773,1069.7;793,1077.7;813,1086.4;833,1096.1;853,1105.9;873,1115.6;893,1125.3;906.15,1131.6;</values>
 		</specificHeatCapacity>
@@ -18,17 +18,10 @@
 		</oxideEmissivity>
 		<oxideHeatOfFormation>0.0</oxideHeatOfFormation>
 		<oxideReactionProbability>0.0</oxideReactionProbability>
-		<youngModulus>
-			<values>297.15,68E9;473.15,59E9;573.15,47E9;773.15,12E9;1000.0,12E9;</values>
-		</youngModulus>
-		<yieldStress>
-			<values>297.15,295E6;473.15,240E6;573.15, 95E6; 773.15,8E6; 1000,8E6;</values>
-		</yieldStress>
 	</metalMaterial>
-
 	<metalMaterial>
-		<name>Unittest_light</name>
-		<density>100.0</density>
+		<name>ATV_Cargo</name>
+		<density>117.64</density>
 		<specificHeatCapacity>
 			<values>293,877.5;313,885.5;333,893.5;353,901.5;373,909.5;393,917.5;413,925.6;433,933.6;453,941.6;473,949.6;493,957.6;513,965.6;533,973.6;553,981.6;573,989.6;593,997.6;613,1005.6;633,1013.6;653,1021.7;673,1029.7;693,1037.7;713,1045.7;733,1053.7;753,1061.7;773,1069.7;793,1077.7;813,1086.4;833,1096.1;853,1105.9;873,1115.6;893,1125.3;906.15,1131.6;</values>
 		</specificHeatCapacity>
@@ -45,45 +38,10 @@
 		</oxideEmissivity>
 		<oxideHeatOfFormation>0.0</oxideHeatOfFormation>
 		<oxideReactionProbability>0.0</oxideReactionProbability>
-		<youngModulus>
-			<values>297.15,68E9;473.15,59E9;573.15,47E9;773.15,12E9;1000.0,12E9;</values>
-		</youngModulus>
-		<yieldStress>
-			<values>297.15,295E6;473.15,240E6;573.15, 95E6; 773.15,8E6; 1000,8E6;</values>
-		</yieldStress>
 	</metalMaterial>
-
 	<metalMaterial>
-		<name>Unittest_demise</name>
-		<density>100.0</density>
-		<specificHeatCapacity>
-			<values>293,877.5;313,885.5;333,893.5;353,901.5;373,909.5;393,917.5;413,925.6;433,933.6;453,941.6;473,949.6;493,957.6;513,965.6;533,973.6;553,981.6;573,989.6;593,997.6;613,1005.6;633,1013.6;653,1021.7;673,1029.7;693,1037.7;713,1045.7;733,1053.7;753,1061.7;773,1069.7;793,1077.7;813,1086.4;833,1096.1;853,1105.9;873,1115.6;893,1125.3;906.15,1131.6;</values>
-		</specificHeatCapacity>
-		<meltingHeat>361500.0</meltingHeat>
-		<meltingTemperature>500.15</meltingTemperature>
-		<emissivity>
-			<values>250.0,0.105;360.0,0.12;580.0,0.14;800.0,0.16;906.15,0.16;</values>
-		</emissivity>
-		<heatConductivity>
-			<values>293,163.89;313,164.95;333,166.53;353,168.46;373,170.61;393,172.84;413,175.05;433,177.10;453,178.92;473,180.43;493,181.58;513,182.31;533,182.60;553,182.44;573,181.84;593,180.83;613,179.45;633,177.78;653,175.93;673,173.97;693,172.06;713,170.36;733,169.08;753,168.39;773,168.54;793,169.05;813,162.63;833,145.74;853,128.19;873,109.69;893,89.99;906.15,77.20739;</values>
-		</heatConductivity>
-		<oxideActivationTemperature>0.0</oxideActivationTemperature>
-		<oxideEmissivity>
-		</oxideEmissivity>
-		<oxideHeatOfFormation>0.0</oxideHeatOfFormation>
-		<oxideReactionProbability>0.0</oxideReactionProbability>
-		<youngModulus>
-			<values>297.15,68E9;473.15,59E9;573.15,47E9;773.15,12E9;1000.0,12E9;</values>
-		</youngModulus>
-		<yieldStress>
-			<values>297.15,295E6;473.15,240E6;573.15, 95E6; 773.15,8E6; 1000,8E6;</values>
-		</yieldStress>
-	</metalMaterial>
-
-
-	<metalMaterial>
-		<name>ATV_cargo</name>
-		<density>471.00</density>
+		<name>ATV_Cap_Prop</name>
+		<density>125.22</density>
 		<specificHeatCapacity>
 			<values>293,877.5;313,885.5;333,893.5;353,901.5;373,909.5;393,917.5;413,925.6;433,933.6;453,941.6;473,949.6;493,957.6;513,965.6;533,973.6;553,981.6;573,989.6;593,997.6;613,1005.6;633,1013.6;653,1021.7;673,1029.7;693,1037.7;713,1045.7;733,1053.7;753,1061.7;773,1069.7;793,1077.7;813,1086.4;833,1096.1;853,1105.9;873,1115.6;893,1125.3;906.15,1131.6;</values>
 		</specificHeatCapacity>
@@ -100,18 +58,10 @@
 		</oxideEmissivity>
 		<oxideHeatOfFormation>0.0</oxideHeatOfFormation>
 		<oxideReactionProbability>0.0</oxideReactionProbability>
-		<youngModulus>
-			<values>297.15,68E9;473.15,59E9;573.15,47E9;773.15,12E9;1000.0,12E9;</values>
-		</youngModulus>
-		<yieldStress>
-			<values>297.15,295E6;473.15,240E6;573.15, 95E6; 773.15,8E6; 1000,8E6;</values>
-		</yieldStress>
 	</metalMaterial>
-
-
 	<metalMaterial>
-		<name>ATV_body</name>
-		<density>173.00</density>
+		<name>ATV_Joints</name>
+		<density>2000.0</density>
 		<specificHeatCapacity>
 			<values>293,877.5;313,885.5;333,893.5;353,901.5;373,909.5;393,917.5;413,925.6;433,933.6;453,941.6;473,949.6;493,957.6;513,965.6;533,973.6;553,981.6;573,989.6;593,997.6;613,1005.6;633,1013.6;653,1021.7;673,1029.7;693,1037.7;713,1045.7;733,1053.7;753,1061.7;773,1069.7;793,1077.7;813,1086.4;833,1096.1;853,1105.9;873,1115.6;893,1125.3;906.15,1131.6;</values>
 		</specificHeatCapacity>
@@ -128,45 +78,9 @@
 		</oxideEmissivity>
 		<oxideHeatOfFormation>0.0</oxideHeatOfFormation>
 		<oxideReactionProbability>0.0</oxideReactionProbability>
-		<youngModulus>
-			<values>297.15,68E9;473.15,59E9;573.15,47E9;773.15,12E9;1000.0,12E9;</values>
-		</youngModulus>
-		<yieldStress>
-			<values>297.15,295E6;473.15,240E6;573.15, 95E6; 773.15,8E6; 1000,8E6;</values>
-		</yieldStress>
 	</metalMaterial>
-
 	<metalMaterial>
-		<name>ATV_body_test</name>
-		<density>79.8</density>
-		<specificHeatCapacity>
-			<values>293,877.5;313,885.5;333,893.5;353,901.5;373,909.5;393,917.5;413,925.6;433,933.6;453,941.6;473,949.6;493,957.6;513,965.6;533,973.6;553,981.6;573,989.6;593,997.6;613,1005.6;633,1013.6;653,1021.7;673,1029.7;693,1037.7;713,1045.7;733,1053.7;753,1061.7;773,1069.7;793,1077.7;813,1086.4;833,1096.1;853,1105.9;873,1115.6;893,1125.3;906.15,1131.6;</values>
-		</specificHeatCapacity>
-		<meltingHeat>361500.0</meltingHeat>
-		<meltingTemperature>906.15</meltingTemperature>
-		<emissivity>
-			<values>250.0,0.105;360.0,0.12;580.0,0.14;800.0,0.16;906.15,0.16;</values>
-		</emissivity>
-		<heatConductivity>
-			<values>293,163.89;313,164.95;333,166.53;353,168.46;373,170.61;393,172.84;413,175.05;433,177.10;453,178.92;473,180.43;493,181.58;513,182.31;533,182.60;553,182.44;573,181.84;593,180.83;613,179.45;633,177.78;653,175.93;673,173.97;693,172.06;713,170.36;733,169.08;753,168.39;773,168.54;793,169.05;813,162.63;833,145.74;853,128.19;873,109.69;893,89.99;906.15,77.20739;</values>
-		</heatConductivity>
-		<oxideActivationTemperature>0.0</oxideActivationTemperature>
-		<oxideEmissivity>
-		</oxideEmissivity>
-		<oxideHeatOfFormation>0.0</oxideHeatOfFormation>
-		<oxideReactionProbability>0.0</oxideReactionProbability>
-		<youngModulus>
-			<values>297.15,68E9;473.15,59E9;573.15,47E9;773.15,12E9;1000.0,12E9;</values>
-		</youngModulus>
-		<yieldStress>
-			<values>297.15,295E6;473.15,240E6;573.15, 95E6; 773.15,8E6; 1000,8E6;</values>
-		</yieldStress>
-	</metalMaterial>
-
-
-
-	<metalMaterial>
-		<name>ATV_panel</name>
+		<name>ATV_Panels</name>
 		<density>50.0</density>
 		<specificHeatCapacity>
 			<values>293,877.5;313,885.5;333,893.5;353,901.5;373,909.5;393,917.5;413,925.6;433,933.6;453,941.6;473,949.6;493,957.6;513,965.6;533,973.6;553,981.6;573,989.6;593,997.6;613,1005.6;633,1013.6;653,1021.7;673,1029.7;693,1037.7;713,1045.7;733,1053.7;753,1061.7;773,1069.7;793,1077.7;813,1086.4;833,1096.1;853,1105.9;873,1115.6;893,1125.3;906.15,1131.6;</values>
@@ -184,147 +98,5 @@
 		</oxideEmissivity>
 		<oxideHeatOfFormation>0.0</oxideHeatOfFormation>
 		<oxideReactionProbability>0.0</oxideReactionProbability>
-		<youngModulus>
-			<values>297.15,68E9;473.15,59E9;573.15,47E9;773.15,12E9;1000.0,12E9;</values>
-		</youngModulus>
-		<yieldStress>
-			<values>297.15,295E6;473.15,240E6;573.15, 95E6; 773.15,8E6; 1000,8E6;</values>
-		</yieldStress>
-	</metalMaterial>
-
-	<metalMaterial>
-		<name>ATV_panel_coverglass</name>
-		<density>2200</density>
-		<specificHeatCapacity>
-			<values>773,750;1273,840</values>
-		</specificHeatCapacity>
-		<meltingHeat>361500.0</meltingHeat>
-		<meltingTemperature>906.15</meltingTemperature>
-		<emissivity>
-			<values>250.0,0.85;1273,0.95;</values>
-		</emissivity>
-		<heatConductivity>
-			<values>373,1.38;773,1.3;1273,1.2;</values>
-		</heatConductivity>
-		<oxideActivationTemperature>0.0</oxideActivationTemperature>
-		<oxideEmissivity>
-		</oxideEmissivity>
-		<oxideHeatOfFormation>0.0</oxideHeatOfFormation>
-		<oxideReactionProbability>0.0</oxideReactionProbability>
-		<youngModulus>
-			<values>297.15,68E9;473.15,59E9;573.15,47E9;773.15,12E9;1000.0,12E9;</values>
-		</youngModulus>
-		<yieldStress>
-			<values>297.15,295E6;473.15,240E6;573.15, 95E6; 773.15,8E6; 1000,8E6;</values>
-		</yieldStress>
-	</metalMaterial>	
-
-
-	<metalMaterial>
-		<name>ATV_joint</name>
-		<density>7134.0</density>
-		<specificHeatCapacity>
-			<values>293,877.5;313,885.5;333,893.5;353,901.5;373,909.5;393,917.5;413,925.6;433,933.6;453,941.6;473,949.6;493,957.6;513,965.6;533,973.6;553,981.6;573,989.6;593,997.6;613,1005.6;633,1013.6;653,1021.7;673,1029.7;693,1037.7;713,1045.7;733,1053.7;753,1061.7;773,1069.7;793,1077.7;813,1086.4;833,1096.1;853,1105.9;873,1115.6;893,1125.3;906.15,1131.6;</values>
-		</specificHeatCapacity>
-		<meltingHeat>361500.0</meltingHeat>
-		<meltingTemperature>906.15</meltingTemperature>
-		<emissivity>
-			<values>250.0,0.105;360.0,0.12;580.0,0.14;800.0,0.16;906.15,0.16;</values>
-		</emissivity>
-		<heatConductivity>
-			<values>293,163.89;313,164.95;333,166.53;353,168.46;373,170.61;393,172.84;413,175.05;433,177.10;453,178.92;473,180.43;493,181.58;513,182.31;533,182.60;553,182.44;573,181.84;593,180.83;613,179.45;633,177.78;653,175.93;673,173.97;693,172.06;713,170.36;733,169.08;753,168.39;773,168.54;793,169.05;813,162.63;833,145.74;853,128.19;873,109.69;893,89.99;906.15,77.20739;</values>
-		</heatConductivity>
-		<oxideActivationTemperature>0.0</oxideActivationTemperature>
-		<oxideEmissivity>
-		</oxideEmissivity>
-		<oxideHeatOfFormation>0.0</oxideHeatOfFormation>
-		<oxideReactionProbability>0.0</oxideReactionProbability>
-		<youngModulus>
-			<values>297.15,68E9;473.15,59E9;573.15,47E9;773.15,12E9;1000.0,12E9;</values>
-		</youngModulus>
-		<yieldStress>
-			<values>297.15,295E6;473.15,240E6;573.15, 95E6; 773.15,8E6; 1000,8E6;</values>
-		</yieldStress>
-	</metalMaterial>
-
-	<metalMaterial>
-	<name>empty</name>
-	<density>0.001</density>
-	<specificHeatCapacity>
-	<values>293,877.5;313,885.5;333,893.5;353,901.5;373,911.5;393,923.5;413,936.6;433,947.6;453,965.6;473,1002.6;493,1068.6;513,1106.6;533,1084.6;553,1049.6;573,1042.6;593,1079.6;613,1120.6;633,1159.6;653,1198.7;673,1233.7;693,1259.7;713,1257.7;733,1102.7;753,1069.7;773,1069.7;793,1077.7;813,1086.4;833,1096.1;850.0,1131.6;</values>
-	</specificHeatCapacity>
-	<meltingHeat>400000.0</meltingHeat>
-	<meltingTemperature>850.0</meltingTemperature>
-	<emissivity>
-	<values>50.0,0.4;</values>
-	</emissivity>
-	<heatConductivity>
-	<values>293,163.89;313,164.95;333,166.53;353,168.46;373,170.61;393,172.84;413,175.05;433,177.10;453,178.92;473,180.43;493,181.58;513,182.31;533,182.60;553,182.44;573,181.84;593,180.83;613,179.45;633,177.78;653,175.93;673,173.97;693,172.06;713,170.36;733,169.08;753,168.39;773,168.54;793,169.05;813,162.63;833,145.74;850.0,128.19;</values>
-	</heatConductivity>
-	<oxideActivationTemperature>0.0</oxideActivationTemperature>
-	<oxideEmissivity> </oxideEmissivity>
-	<oxideHeatOfFormation>0.0</oxideHeatOfFormation>
-	<oxideReactionProbability>0.0</oxideReactionProbability>
-	<youngModulus>
-	<values>297.15,68E9;473.15,59E9;573.15,47E9;773.15,12E9;1000.0,12E9;</values>
-	</youngModulus>
-	<yieldStress>
-	<values>297.15,295E6;473.15,240E6;573.15, 95E6; 773.15,8E6; 1000,8E6;</values>
-	</yieldStress>
-	</metalMaterial>
-
-	<metalMaterial>
-	<name>fenics</name>
-	<density>2000.0</density>
-	<specificHeatCapacity>
-	<values>293,877.5;313,885.5;333,893.5;353,901.5;373,911.5;393,923.5;413,936.6;433,947.6;453,965.6;473,1002.6;493,1068.6;513,1106.6;533,1084.6;553,1049.6;573,1042.6;593,1079.6;613,1120.6;633,1159.6;653,1198.7;673,1233.7;693,1259.7;713,1257.7;733,1102.7;753,1069.7;773,1069.7;793,1077.7;813,1086.4;833,1096.1;850.0,1131.6;</values>
-	</specificHeatCapacity>
-	<meltingHeat>400000.0</meltingHeat>
-	<meltingTemperature>850.0</meltingTemperature>
-	<emissivity>
-	<values>50.0,0.4;</values>
-	</emissivity>
-	<heatConductivity>
-	<values>293,163.89;313,164.95;333,166.53;353,168.46;373,170.61;393,172.84;413,175.05;433,177.10;453,178.92;473,180.43;493,181.58;513,182.31;533,182.60;553,182.44;573,181.84;593,180.83;613,179.45;633,177.78;653,175.93;673,173.97;693,172.06;713,170.36;733,169.08;753,168.39;773,168.54;793,169.05;813,162.63;833,145.74;850.0,128.19;</values>
-	</heatConductivity>
-	<oxideActivationTemperature>0.0</oxideActivationTemperature>
-	<oxideEmissivity> </oxideEmissivity>
-	<oxideHeatOfFormation>0.0</oxideHeatOfFormation>
-	<oxideReactionProbability>0.0</oxideReactionProbability>
-	<youngModulus>
-	<values>297.15,68E9;473.15,59E9;573.15,47E9;773.15,12E9;1000.0,12E9;</values>
-	</youngModulus>
-	<yieldStress>
-	<values>297.15,295E6;473.15,240E6;573.15, 95E6; 773.15,8E6; 1000,8E6;</values>
-	</yieldStress>
-	</metalMaterial>
-
-	<metalMaterial>
-	<name>AL-7075-const</name>
-	<density>2813.0</density>
-	<specificHeatCapacity>
-	<values>293,1004.55;8000.0,1004.55;</values>
-	</specificHeatCapacity>
-	<meltingHeat>400000.0</meltingHeat>
-	<meltingTemperature>850.0</meltingTemperature>
-	<emissivity>
-	<values>50.0,0.4;8000.0,0.4;</values>
-	</emissivity>
-	<heatConductivity>
-	<values>293,146.04;8000.0,146.04;</values>
-	</heatConductivity>
-	<oxideActivationTemperature>0.0</oxideActivationTemperature>
-	<oxideEmissivity> </oxideEmissivity>
-	<oxideHeatOfFormation>0.0</oxideHeatOfFormation>
-	<oxideReactionProbability>0.0</oxideReactionProbability>
-	<youngModulus>
-	<values>297.15,68E9;473.15,59E9;573.15,47E9;773.15,12E9;1000.0,12E9;</values>
-	</youngModulus>
-	<yieldStress>
-	<values>297.15,295E6;473.15,240E6;573.15, 95E6; 773.15,8E6; 1000,8E6;</values>
-	</yieldStress>
-	</metalMaterial>	
-
+		<metalMaterial>
 </materialList>
-
-

--- a/Output/output.py
+++ b/Output/output.py
@@ -22,7 +22,6 @@ import numpy as np
 import os
 import meshio
 from pathlib import Path
-from Dynamics.propagation import update_dynamic_attributes
 
 def write_output_data(titan, options, just_smooth=False):
 
@@ -173,17 +172,6 @@ def write_output_data(titan, options, just_smooth=False):
             
             df = df.round(decimals = 6)
             df.to_csv(options.output_folder + '/Data/'+ 'data_assembly.csv', mode='a' ,header=not os.path.exists(options.output_folder + '/Data/data_assembly.csv'), index = False)
-
-def write_dense_output(titan,options, timeseries, interpolant):
-    
-    ## Firstly want the shape of the output, this is at present...
-    states = [np.reshape(interpolant(time),[-1,13]) for time in timeseries]
-    for i_assem, _assembly in enumerate(titan.assembly):
-        assem_states = np.array([_state[i_assem,:] for _state in states])
-        assem_data = np.zeros([len(timeseries),58+len(_assembly.freestream.species_index)])
-        
-
-
 
 def write_to_series(data_array,columns,filename):
     import pandas as pd

--- a/Output/output.py
+++ b/Output/output.py
@@ -23,7 +23,7 @@ import os
 import meshio
 from pathlib import Path
 
-def write_output_data(titan, options, just_smooth=False):
+def write_output_data(titan, options, smooth=False):
 
     df = pd.DataFrame()
 
@@ -90,7 +90,15 @@ def write_output_data(titan, options, just_smooth=False):
         df['VelRoll'] =  [assembly.roll_vel*180/np.pi]
         df['VelPitch'] = [assembly.pitch_vel*180/np.pi]
         df['VelYaw'] =   [assembly.yaw_vel*180/np.pi]
-        df['magnitudeOmega'] = np.linalg.norm([assembly.roll_vel,assembly.pitch_vel,assembly.yaw_vel])*180/np.pi
+        
+        omega= np.array([assembly.roll_vel,assembly.pitch_vel,assembly.yaw_vel])
+        angular_momentum = assembly.inertia @ omega
+
+        df['magnitudeOmega'] = np.linalg.norm(omega)*180/np.pi
+        df['angularMomentum_x'] = angular_momentum[0]
+        df['angularMomentum_y'] = angular_momentum[1]
+        df['angularMomentum_z'] = angular_momentum[2]
+        df['magnitudeAngularMomentum'] = np.linalg.norm(angular_momentum)
 
         #Quaternion Body -> ECEF frame        
         df['Quat_w']   = [assembly.quaternion[3]]
@@ -147,10 +155,11 @@ def write_output_data(titan, options, just_smooth=False):
         df = pd.concat([df, df_mass], axis = 1)
 
         df = df.round(decimals = 12)
-        if options.time_fidelity>0.0:
-            df.to_csv(options.output_folder + '/Data/'+ 'data_smooth.csv', mode='a' ,header=not os.path.exists(options.output_folder + '/Data/data_smooth.csv'), index = False)    
-            if just_smooth: return
-        df.to_csv(options.output_folder + '/Data/'+ 'data.csv', mode='a' ,header=not os.path.exists(options.output_folder + '/Data/data.csv'), index = False)
+        if options.time_fidelity>0.0 and smooth:
+            df.to_csv(options.output_folder + '/Data/'+ 'data_smooth.csv', mode='a' ,header=not os.path.exists(options.output_folder + '/Data/data_smooth.csv'), index = False)
+            return
+        elif not smooth:
+            df.to_csv(options.output_folder + '/Data/'+ 'data.csv', mode='a' ,header=not os.path.exists(options.output_folder + '/Data/data.csv'), index = False)
 
     df = pd.DataFrame()
     for assembly in titan.assembly:
@@ -228,11 +237,11 @@ def generate_surface_solution(titan, options, iter_value, folder = 'Surface_solu
         
         cells = {"triangle": facets}
 
-        cell_data = { "Pressure": [pressure],
-                      "Heatflux": [heatflux],
-                      "Temperature": [temperature],
-                      "Shear": [shear],
-                      "Theta": [theta],
+        cell_data = { "pressure": [pressure],
+                      "heatflux": [heatflux],
+                      "temperature": [temperature],
+                      "shear": [shear],
+                      "theta": [theta],
                       #"Enthalpy BLE": [he],
                       #"Enthalpy Wall": [hw],
                       #"Temperatue BLE": [Te],
@@ -242,7 +251,7 @@ def generate_surface_solution(titan, options, iter_value, folder = 'Surface_solu
             if options.thermal.ablation_mode == 'PATO':
                 cell_data["mDotVapor"] = [mDotVapor]
                 cell_data["mDotMelt"]  = [mDotMelt]
-        point_data = { "Displacement": displacement}
+        point_data = { "displacement": displacement}
 
         trimesh = meshio.Mesh(points,
                               cells=cells,
@@ -254,6 +263,153 @@ def generate_surface_solution(titan, options, iter_value, folder = 'Surface_solu
 
         vol_mesh_filepath = f"{folder_path}/solution_iter_{str(iter_value).zfill(3)}.xdmf"
         meshio.write(vol_mesh_filepath, trimesh, file_format="xdmf")
+
+## The following funcs split generate_surface_solution() into separate create, update and
+# write functions. At the moment this is something of a messy repeat but in future having
+# these be separate could give a minor speedup, see the dense solution pipeline for an
+#  example of this  
+
+def create_surface_solution(titan, options):
+    solutions = []
+    points = np.array([])
+    facets = np.array([])
+    pressure = np.array([])
+    shear = np.array([])
+    heatflux = np.array([])
+    #hf_cond = np.array([])
+    #radius = np.array([])
+    #ellipse = np.array([])
+    #cellID = np.array([])
+    #emissive_power = np.array([])
+    theta = np.array([])
+    #he = np.array([])
+    #hw = np.array([])
+    #Te = np.array([])
+    mDotVapor = np.array([])
+    mDotMelt = np.array([])
+
+
+    for assembly in titan.assembly:
+        points = assembly.mesh.nodes - assembly.mesh.surface_displacement
+        facets = assembly.mesh.facets
+        pressure = assembly.aerothermo.pressure
+        heatflux = assembly.aerothermo.heatflux
+        shear = assembly.aerothermo.shear
+        displacement = assembly.mesh.surface_displacement
+        # radius = assembly.mesh.facet_radius
+        # ellipse = assembly.inside_shock
+        temperature  = assembly.aerothermo.temperature
+        # emissive_power = assembly.emissive_power
+        theta = assembly.aerothermo.theta
+        # he = assembly.aerothermo.he
+        # hw = assembly.aerothermo.hw
+        # Te = assembly.aerothermo.Te
+
+        if options.thermal.ablation_mode.lower() == 'pato' and options.pato.Ta_bc == 'ablation':
+            mDotVapor = np.zeros(len(assembly.mesh.facets))
+            mDotMelt  = np.zeros(len(assembly.mesh.facets))
+            mDotVapor = assembly.mDotVapor
+            mDotMelt = assembly.mDotMelt
+        #hf_cond = assembly.hf_cond
+
+        #cellID = np.arange(len(assembly.mesh.facets))
+        # for cellid in range(len(assembly.mesh.facets)):
+        #     cellID = np.append(cellID, cellid)
+
+        
+        cells = {"triangle": facets}
+
+        cell_data = { "pressure": [pressure],
+                      "heatflux": [heatflux],
+                      "temperature": [temperature],
+                      "shear": [shear],
+                      "theta": [theta],
+                      #"Enthalpy BLE": [he],
+                      #"Enthalpy Wall": [hw],
+                      #"Temperatue BLE": [Te],
+                    }
+        # I don't believe He, Hw and Te are functional at present
+        if options.thermal.ablation:
+            if options.thermal.ablation_mode == 'PATO':
+                cell_data["mDotVapor"] = [mDotVapor]
+                cell_data["mDotMelt"]  = [mDotMelt]
+        point_data = { "displacement": displacement}
+
+        trimesh = meshio.Mesh(points,
+                              cells=cells,
+                              point_data = point_data,
+                              cell_data = cell_data)
+        solutions.append(trimesh)
+    return solutions
+
+def update_surface_solution(titan,options,solutions,overwrite=None):
+    points = np.array([])
+    facets = np.array([])
+    pressure = np.array([])
+    shear = np.array([])
+    heatflux = np.array([])
+    #hf_cond = np.array([])
+    #radius = np.array([])
+    #ellipse = np.array([])
+    #cellID = np.array([])
+    #emissive_power = np.array([])
+    theta = np.array([])
+    #he = np.array([])
+    #hw = np.array([])
+    #Te = np.array([])
+    mDotVapor = np.array([])
+    mDotMelt = np.array([])
+    for i_assem, _assembly in enumerate(titan.assembly):
+            # points = assembly.mesh.nodes - assembly.mesh.surface_displacement
+        # facets = assembly.mesh.facets
+        if overwrite is not None:
+            pressure = overwrite[i_assem]['pressure'][:]
+            heatflux = overwrite[i_assem]['heatflux'][:]
+            shear = overwrite[i_assem]['shear'][:]
+            
+            temperature = overwrite[i_assem]['temperature'][:]
+            theta = overwrite[i_assem]['theta'][:]
+        else:
+            pressure = _assembly.aerothermo.pressure
+            heatflux = _assembly.aerothermo.heatflux
+            shear = _assembly.aerothermo.shear
+            # radius = assembly.mesh.facet_radius
+            # ellipse = assembly.inside_shock
+            temperature  = _assembly.aerothermo.temperature
+            # emissive_power = assembly.emissive_power
+            theta = _assembly.aerothermo.theta
+            # he = assembly.aerothermo.he
+            # hw = assembly.aerothermo.hw
+            # Te = assembly.aerothermo.Te
+        displacement = _assembly.mesh.surface_displacement
+
+        if options.thermal.ablation_mode.lower() == 'pato' and options.pato.Ta_bc == 'ablation':
+            mDotVapor = np.zeros(len(_assembly.mesh.facets))
+            mDotMelt  = np.zeros(len(_assembly.mesh.facets))
+            if overwrite is not None:
+                mDotVapor = overwrite[i_assem]['mDotVapor'][:]
+                mDotMelt = overwrite[i_assem]['mDotMelt'][:]
+            else:
+                mDotVapor = _assembly.mDotVapor
+                mDotMelt  = _assembly.mDotMelt
+            solutions[i_assem].cell_data["mDotVapor"][:] = mDotVapor
+            solutions[i_assem].cell_data["mDotMelt"][:]  = mDotMelt
+
+        solutions[i_assem].cell_data["pressure"][:] = pressure
+        solutions[i_assem].cell_data["heatflux"][:] = heatflux
+        solutions[i_assem].cell_data["temperature"][:] = temperature
+        solutions[i_assem].cell_data["shear"][:] = shear
+        solutions[i_assem].cell_data["theta"][:] = theta
+        solutions[i_assem].point_data["displacement"][:] = displacement
+        return solutions
+
+def write_surface_solution(options,solutions,IDS,iter_value,folder='Surface_solution'):
+    for trimesh, assembly_id in zip(solutions,IDS):
+        folder_path = options.output_folder+'/' + folder + '/ID_'+str(assembly_id)
+        Path(folder_path).mkdir(parents=True, exist_ok=True)
+
+        vol_mesh_filepath = f"{folder_path}/solution_iter_{str(iter_value).zfill(3)}.vtk"
+        meshio.write(vol_mesh_filepath, trimesh, file_format="vtk")
 
 def generate_surface_solution_emissions(titan, options, iter_value, folder = 'Surface_solution'):
 

--- a/Output/output.py
+++ b/Output/output.py
@@ -206,6 +206,7 @@ def generate_surface_solution(titan, options, iter_value, folder = 'Surface_solu
     Te = np.array([])
     mDotVapor = np.array([])
     mDotMelt = np.array([])
+    debug_alpha = np.array([])
 
 
     for assembly in titan.assembly:
@@ -225,6 +226,7 @@ def generate_surface_solution(titan, options, iter_value, folder = 'Surface_solu
         Te = assembly.aerothermo.Te
         mDotVapor = np.zeros(len(assembly.mesh.facets))
         mDotMelt  = np.zeros(len(assembly.mesh.facets))
+        debug_alpha = assembly.aerothermo.debug_alpha
         if options.thermal.ablation_mode.lower() == 'pato' and options.pato.Ta_bc == 'ablation':
             mDotVapor = assembly.mDotVapor
             mDotMelt = assembly.mDotMelt
@@ -242,6 +244,7 @@ def generate_surface_solution(titan, options, iter_value, folder = 'Surface_solu
                       "temperature": [temperature],
                       "shear": [shear],
                       "theta": [theta],
+                      "debug_alpha" : [debug_alpha]
                       #"Enthalpy BLE": [he],
                       #"Enthalpy Wall": [hw],
                       #"Temperatue BLE": [Te],
@@ -287,6 +290,7 @@ def create_surface_solution(titan, options):
     #Te = np.array([])
     mDotVapor = np.array([])
     mDotMelt = np.array([])
+    debug_alpha = np.array([])
 
 
     for assembly in titan.assembly:
@@ -304,6 +308,7 @@ def create_surface_solution(titan, options):
         # he = assembly.aerothermo.he
         # hw = assembly.aerothermo.hw
         # Te = assembly.aerothermo.Te
+        debug_alpha = assembly.aerothermo.debug_alpha
 
         if options.thermal.ablation_mode.lower() == 'pato' and options.pato.Ta_bc == 'ablation':
             mDotVapor = np.zeros(len(assembly.mesh.facets))
@@ -324,6 +329,7 @@ def create_surface_solution(titan, options):
                       "temperature": [temperature],
                       "shear": [shear],
                       "theta": [theta],
+                      "debug_alpha" : [debug_alpha]
                       #"Enthalpy BLE": [he],
                       #"Enthalpy Wall": [hw],
                       #"Temperatue BLE": [Te],
@@ -359,6 +365,7 @@ def update_surface_solution(titan,options,solutions,overwrite=None):
     #Te = np.array([])
     mDotVapor = np.array([])
     mDotMelt = np.array([])
+    debug_alpha = np.array([])
     for i_assem, _assembly in enumerate(titan.assembly):
             # points = assembly.mesh.nodes - assembly.mesh.surface_displacement
         # facets = assembly.mesh.facets
@@ -369,6 +376,7 @@ def update_surface_solution(titan,options,solutions,overwrite=None):
             
             temperature = overwrite[i_assem]['temperature'][:]
             theta = overwrite[i_assem]['theta'][:]
+            debug_alpha = overwrite[i_assem]['debug_alpha'][:]
         else:
             pressure = _assembly.aerothermo.pressure
             heatflux = _assembly.aerothermo.heatflux
@@ -381,6 +389,7 @@ def update_surface_solution(titan,options,solutions,overwrite=None):
             # he = assembly.aerothermo.he
             # hw = assembly.aerothermo.hw
             # Te = assembly.aerothermo.Te
+            debug_alpha = _assembly.aerothermo.debug_alpha
         displacement = _assembly.mesh.surface_displacement
 
         if options.thermal.ablation_mode.lower() == 'pato' and options.pato.Ta_bc == 'ablation':
@@ -401,6 +410,7 @@ def update_surface_solution(titan,options,solutions,overwrite=None):
         solutions[i_assem].cell_data["shear"][:] = shear
         solutions[i_assem].cell_data["theta"][:] = theta
         solutions[i_assem].point_data["displacement"][:] = displacement
+        solutions[i_assem].cell_data["debug_alpha"][:] = debug_alpha
         return solutions
 
 def write_surface_solution(options,solutions,IDS,iter_value,folder='Surface_solution'):
@@ -408,8 +418,8 @@ def write_surface_solution(options,solutions,IDS,iter_value,folder='Surface_solu
         folder_path = options.output_folder+'/' + folder + '/ID_'+str(assembly_id)
         Path(folder_path).mkdir(parents=True, exist_ok=True)
 
-        vol_mesh_filepath = f"{folder_path}/solution_iter_{str(iter_value).zfill(3)}.vtk"
-        meshio.write(vol_mesh_filepath, trimesh, file_format="vtk")
+        vol_mesh_filepath = f"{folder_path}/solution_iter_{str(iter_value).zfill(3)}.xdmf"
+        meshio.write(vol_mesh_filepath, trimesh, file_format="xdmf")
 
 def generate_surface_solution_emissions(titan, options, iter_value, folder = 'Surface_solution'):
 

--- a/Output/output.py
+++ b/Output/output.py
@@ -22,8 +22,9 @@ import numpy as np
 import os
 import meshio
 from pathlib import Path
+from Dynamics.propagation import update_dynamic_attributes
 
-def write_output_data(titan, options):
+def write_output_data(titan, options, just_smooth=False):
 
     df = pd.DataFrame()
 
@@ -111,7 +112,7 @@ def write_output_data(titan, options):
         df['Temperature'] = [assembly.freestream.temperature]
         df['Pressure'] = [assembly.freestream.pressure]
         df['SpecificHeatRatio'] = [assembly.freestream.gamma]
-        df['Qint'] = [np.sum(assembly.aerothermo.heatflux*assembly.mesh.facet_area)]
+        #df['Qint'] = [np.sum(assembly.aerothermo.heatflux*assembly.mesh.facet_area)]
         df['qmax'] = [max(assembly.aerothermo.heatflux)]
         df['Tmax'] = [max(assembly.aerothermo.temperature)]
         df['knudsen'] = [assembly.freestream.knudsen]
@@ -147,6 +148,9 @@ def write_output_data(titan, options):
         df = pd.concat([df, df_mass], axis = 1)
 
         df = df.round(decimals = 12)
+        if options.time_fidelity>0.0:
+            df.to_csv(options.output_folder + '/Data/'+ 'data_smooth.csv', mode='a' ,header=not os.path.exists(options.output_folder + '/Data/data_smooth.csv'), index = False)    
+            if just_smooth: return
         df.to_csv(options.output_folder + '/Data/'+ 'data.csv', mode='a' ,header=not os.path.exists(options.output_folder + '/Data/data.csv'), index = False)
 
     df = pd.DataFrame()
@@ -169,6 +173,17 @@ def write_output_data(titan, options):
             
             df = df.round(decimals = 6)
             df.to_csv(options.output_folder + '/Data/'+ 'data_assembly.csv', mode='a' ,header=not os.path.exists(options.output_folder + '/Data/data_assembly.csv'), index = False)
+
+def write_dense_output(titan,options, timeseries, interpolant):
+    
+    ## Firstly want the shape of the output, this is at present...
+    states = [np.reshape(interpolant(time),[-1,13]) for time in timeseries]
+    for i_assem, _assembly in enumerate(titan.assembly):
+        assem_states = np.array([_state[i_assem,:] for _state in states])
+        assem_data = np.zeros([len(timeseries),58+len(_assembly.freestream.species_index)])
+        
+
+
 
 def write_to_series(data_array,columns,filename):
     import pandas as pd
@@ -218,8 +233,9 @@ def generate_surface_solution(titan, options, iter_value, folder = 'Surface_solu
             mDotMelt = assembly.mDotMelt
         #hf_cond = assembly.hf_cond
 
-        for cellid in range(len(assembly.mesh.facets)):
-            cellID = np.append(cellID, cellid)
+        #cellID = np.arange(len(assembly.mesh.facets))
+        # for cellid in range(len(assembly.mesh.facets)):
+        #     cellID = np.append(cellID, cellid)
 
         
         cells = {"triangle": facets}

--- a/Postprocess/postprocess.py
+++ b/Postprocess/postprocess.py
@@ -101,7 +101,7 @@ def generate_visualization(options, data, iter_value, postprocess = "wind", filt
 		if not is_dense:
 			mesh.append(meshio.read(options.output_folder+'/Surface_solution/ID_'+str(int(_id))+'/solution_iter_'+str(iter_value).zfill(3)+'.xdmf'))
 		else:
-			mesh.append(meshio.read(options.output_folder+'/Dense_surface_solution/ID_'+str(int(_id))+'/solution_iter_'+str(iter_value).zfill(3)+'.vtk'))
+			mesh.append(meshio.read(options.output_folder+'/Dense_surface_solution/ID_'+str(int(_id))+'/solution_iter_'+str(iter_value).zfill(3)+'.xdmf'))
 		
 		R_B_ECEF = Rot.from_quat(q[i])
 
@@ -132,6 +132,14 @@ def generate_visualization(options, data, iter_value, postprocess = "wind", filt
 			
 			R_ECEF_W = R_NED_W*R_ECEF_NED
 			mesh[i].points = (R_ECEF_W).apply(mesh[i].points)
+	elif postprocess.lower() == "int":
+		#Rotate ECEF -> largest object frame
+		R_ECEF_B = Rot.from_quat(q[index_mass]).inv().as_matrix()
+		for i, _id in enumerate(assembly_ID):
+			
+			
+			mesh[i].points = mesh[i].points @ R_ECEF_B.T
+
 
 	#Create new mesh
 	points = mesh[0].points
@@ -139,6 +147,7 @@ def generate_visualization(options, data, iter_value, postprocess = "wind", filt
 	pressure = mesh[0].cell_data['pressure']
 	heatflux = mesh[0].cell_data['heatflux']
 	temperature  = mesh[0].cell_data['temperature']
+	debug_alpha = mesh[0].cell_data['debug_alpha']
 
 	facet_dev = len(points)
 
@@ -149,6 +158,7 @@ def generate_visualization(options, data, iter_value, postprocess = "wind", filt
 		pressure = np.append(pressure,mesh[i].cell_data['pressure'])
 		heatflux = np.append(heatflux,mesh[i].cell_data['heatflux'])
 		temperature = np.append(temperature, mesh[i].cell_data['temperature'])
+		debug_alpha = np.append(debug_alpha, mesh[i].cell_data['debug_alpha'])
 
 		facet_dev = len(points)
 
@@ -157,12 +167,14 @@ def generate_visualization(options, data, iter_value, postprocess = "wind", filt
 	cell_data = {"pressure": pressure,
                   "heatflux": heatflux,
                   "temperature": temperature,
+				  "debug_alpha" : debug_alpha
 				 }
 
 	if len(assembly_ID) > 1:
 		cell_data = {"pressure": [pressure],
                   "heatflux": [heatflux],
                   "temperature": [temperature],
+				  "debug_alpha": [debug_alpha]
 				 }	
 
 	trimesh = meshio.Mesh(
@@ -170,4 +182,5 @@ def generate_visualization(options, data, iter_value, postprocess = "wind", filt
         cells=cells,
         cell_data = cell_data)
 	iter_write = iter_override if iter_override is not None else iter_value
-	trimesh.write(options.output_folder+'/Postprocess/'+ 'solution_iter_' + str(iter_write).zfill(3)+'.xdmf')
+	if not os.path.exists(options.output_folder+'/Postprocess_{}'.format(postprocess.lower())): os.mkdir(options.output_folder+'/Postprocess_{}'.format(postprocess.lower()))
+	trimesh.write(options.output_folder+'/Postprocess_{}/'.format(postprocess.lower())+ 'solution_iter_' + str(iter_write).zfill(3)+'.xdmf')

--- a/Postprocess/postprocess.py
+++ b/Postprocess/postprocess.py
@@ -17,6 +17,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
+import os
 import pandas as pd
 import numpy as np
 import meshio
@@ -24,26 +25,36 @@ from Dynamics import frames
 from scipy.spatial.transform import Rotation as Rot
 
 def postprocess(options, postprocess = "wind", filter_name = None):
+	if not os.path.exists(options.output_folder+'/Dense_surface_solution'):
+		data = pd.read_csv(options.output_folder+'/Data/data.csv', index_col = False)
+		data_obj = pd.read_csv(options.output_folder+'/Data/data_assembly.csv', index_col = False)
 
-	data = pd.read_csv(options.output_folder+'/Data/data.csv', index_col = False)
-	data_obj = pd.read_csv(options.output_folder+'/Data/data_assembly.csv', index_col = False)
+		iter_interval = np.unique(data['Iter'].to_numpy())
+		
+		for iter_value in range(0, max(iter_interval)+1, options.output_freq):
+			generate_visualization(options, data, iter_value, postprocess, filter_name, data_obj)
+	else:
+		data_smooth = pd.read_csv(options.output_folder+'/Data/data_smooth.csv')
 
-	iter_interval = np.unique(data['Iter'].to_numpy())
-	
-	for iter_value in range(0, max(iter_interval)+1, options.output_freq):
-		generate_visualization(options, data, iter_value, postprocess, filter_name, data_obj)
+		times = np.unique(data_smooth['Time'].to_numpy())
 
-def generate_visualization(options, data, iter_value, postprocess = "wind", filter_name = None, data_obj = None):
+		for i_time, time in enumerate(times):
+			generate_visualization(options, data_smooth, np.round(time,6), postprocess,is_dense=True, iter_override=i_time)
 
-	index = data['Iter']==iter_value
+def generate_visualization(options, data, iter_value, postprocess = "wind", filter_name = None, data_obj = None, is_dense=False, iter_override=None):
+
+	if not is_dense:
+		index = data['Iter']==iter_value
+	else: index = data['Time']==iter_value
 
 	assembly_ID = data[index]['Assembly_ID'].to_numpy()
 
 	if filter_name:
+		if is_dense: raise NotImplementedError
 		assembly_obj = data_obj[(data_obj['Iter'] == iter_value)*(data_obj['Parent_part'].str.contains(filter_name))]['Assembly_ID'].to_numpy()
 		index = (data['Iter']==iter_value)*(data['Assembly_ID']==assembly_obj[0])
 		assembly_ID = data[index]['Assembly_ID'].to_numpy()
-
+	print(data[index])
 	latitude    = data[index]['Latitude'].to_numpy()/180*np.pi
 	altitude    = data[index]['Altitude'].to_numpy()
 	longitude   = data[index]['Longitude'].to_numpy()/180*np.pi
@@ -87,12 +98,15 @@ def generate_visualization(options, data, iter_value, postprocess = "wind", filt
 	#Read mesh information and surface quantities, place them on the ECEF
 	mesh = []
 	for i, _id in enumerate(assembly_ID):
-		mesh.append(meshio.read(options.output_folder+'/Surface_solution/ID_'+str(_id)+'/solution_iter_'+str(iter_value).zfill(3)+'.xdmf'))
+		if not is_dense:
+			mesh.append(meshio.read(options.output_folder+'/Surface_solution/ID_'+str(int(_id))+'/solution_iter_'+str(iter_value).zfill(3)+'.xdmf'))
+		else:
+			mesh.append(meshio.read(options.output_folder+'/Dense_surface_solution/ID_'+str(int(_id))+'/solution_iter_'+str(iter_value).zfill(3)+'.vtk'))
 		
 		R_B_ECEF = Rot.from_quat(q[i])
 
 		#Apply Displacement due to the use of FEniCS
-		mesh[i].points += mesh[i].point_data['Displacement']
+		mesh[i].points += mesh[i].point_data['displacement']
 
 		#Translate the assembly to (0,0,0)
 		mesh[i].points -= np.array([body_X[i],body_Y[i],body_Z[i]])
@@ -122,9 +136,9 @@ def generate_visualization(options, data, iter_value, postprocess = "wind", filt
 	#Create new mesh
 	points = mesh[0].points
 	facets = mesh[0].cells[0].data
-	pressure = mesh[0].cell_data['Pressure']
-	heatflux = mesh[0].cell_data['Heatflux']
-	temperature  = mesh[0].cell_data['Temperature']
+	pressure = mesh[0].cell_data['pressure']
+	heatflux = mesh[0].cell_data['heatflux']
+	temperature  = mesh[0].cell_data['temperature']
 
 	facet_dev = len(points)
 
@@ -132,22 +146,22 @@ def generate_visualization(options, data, iter_value, postprocess = "wind", filt
 		if i == 0: continue
 		points = np.append(points, mesh[i].points, axis = 0)
 		facets = np.append(facets, mesh[i].cells[-1].data+facet_dev, axis = 0)
-		pressure = np.append(pressure,mesh[i].cell_data['Pressure'])
-		heatflux = np.append(heatflux,mesh[i].cell_data['Heatflux'])
-		temperature = np.append(temperature, mesh[i].cell_data['Temperature'])
+		pressure = np.append(pressure,mesh[i].cell_data['pressure'])
+		heatflux = np.append(heatflux,mesh[i].cell_data['heatflux'])
+		temperature = np.append(temperature, mesh[i].cell_data['temperature'])
 
 		facet_dev = len(points)
 
 	cells = {"triangle": facets}
 
-	cell_data = {"Pressure": pressure,
-                  "Heatflux": heatflux,
+	cell_data = {"pressure": pressure,
+                  "heatflux": heatflux,
                   "temperature": temperature,
 				 }
 
 	if len(assembly_ID) > 1:
-		cell_data = {"Pressure": [pressure],
-                  "Heatflux": [heatflux],
+		cell_data = {"pressure": [pressure],
+                  "heatflux": [heatflux],
                   "temperature": [temperature],
 				 }	
 
@@ -155,5 +169,5 @@ def generate_visualization(options, data, iter_value, postprocess = "wind", filt
         points,
         cells=cells,
         cell_data = cell_data)
-
-	trimesh.write(options.output_folder+'/Postprocess/'+ 'solution_iter_' + str(iter_value).zfill(3)+'.xdmf')
+	iter_write = iter_override if iter_override is not None else iter_value
+	trimesh.write(options.output_folder+'/Postprocess/'+ 'solution_iter_' + str(iter_write).zfill(3)+'.xdmf')

--- a/TITAN.py
+++ b/TITAN.py
@@ -65,7 +65,12 @@ def loop(options = [], titan = []):
         titan.assembly[0].mass = options.vehicle.mass   
 
     if options.dynamic_plots: plot = dynamic_plots.initialise_figs(titan, options)
-
+    if options.postproc_in_loop is not None: 
+        import numpy as np
+        import pandas as pd
+        import os
+        pp_existing = np.array([])
+        i_time=0
     while titan.iter < options.iters:
         options.high_fidelity_flag = False
 
@@ -100,6 +105,25 @@ def loop(options = [], titan = []):
         
         if options.dynamic_plots:
             for _assembly in titan.assembly: plot = dynamic_plots.update_plot(_assembly, plot, titan.time)
+
+        if options.postproc_in_loop is not None:
+            if not os.path.exists(options.output_folder+'/Dense_surface_solution') and os.path.exists(options.output_folder+'/Data/data.csv'):
+                data = pd.read_csv(options.output_folder+'/Data/data.csv', index_col = False)
+                data_obj = pd.read_csv(options.output_folder+'/Data/data_assembly.csv', index_col = False)
+                iter_interval = np.unique(data['Iter'].to_numpy())
+                iters_to_run = iter_interval[~np.isin(iter_interval,pp_existing)]
+                for iter_value in range(min(iters_to_run), max(iters_to_run)+1, options.output_freq):
+                    pp.generate_visualization(options, data, iter_value, options.postproc_in_loop, filter_name, data_obj)
+                pp_existing = np.hstack((pp_existing,iters_to_run))
+            if os.path.exists(options.output_folder+'/Data/data_smooth.csv'):
+                data_smooth = pd.read_csv(options.output_folder+'/Data/data_smooth.csv')
+                times = np.unique(data_smooth['Time'].to_numpy())
+                times_to_run = times[~np.isin(times, pp_existing)]
+                for time in times_to_run:
+                    pp.generate_visualization(options, data_smooth, np.round(time,6), options.postproc_in_loop,is_dense=True, iter_override=i_time)
+                    i_time+=1
+                pp_existing = np.hstack((pp_existing,times_to_run))
+
 
         titan.iter += 1
         titan.post_event_iter +=1
@@ -179,7 +203,7 @@ if __name__ == "__main__":
     postprocess = args.postprocess
     filter_name = args.filtername
     emissions = args.emissions
-    if postprocess and (postprocess.lower()!="wind" and postprocess.lower()!="ecef"):
-        raise Exception("Postprocess can only be WIND or ECEF")
+    if postprocess and (postprocess.lower()!="wind" and postprocess.lower()!="ecef" and postprocess.lower()!="int"):
+        raise Exception("Postprocess can only be WIND, ECEF or INT")
 
     main(filename = filename, postprocess = postprocess, filter_name = filter_name, emissions = emissions)

--- a/pip_requirements.txt
+++ b/pip_requirements.txt
@@ -5,3 +5,4 @@ open3d==0.18.0
 trimesh==4.1.3
 pymap3d
 vg
+python-fcl


### PR DESCRIPTION
This PR merges a collection of work to finalise adaptive dynamics such that it is compatible with all other features of TITAN. As such, functionality was ensured for the following features.

### Local Interpolants for Data Output
As scipy ODE solver produces a local interpolant for each timestep it would be ideal if the user could specify a level of fidelity in time and receive data at that resolution. This has been implemented.

Specify _Time\_fidelity=_ in the **[Options]** section when using adaptive time-stepping to generate _data\_smooth.csv_ (alongside the "canonical" _data.csv_), which can report data at an arbitrary resolution. 

In addition to this specifying _Write\_dense\_solutions=True_ again in the **[Options]** section will additionally output a linearly interpolated surface solution at each time reported in _data\_smooth.csv_. This enables the generation of arbitrarily smooth postprocessing results and animations. Note that since these solutions are not "real" flow solves that artifacts may exist in relation to flow shadows.

It has never been easier to fill your hard drive with TITAN simulations!

### Collision Model for Adaptive Dynamics
Compatibility between the collision model and adaptive dynamics has been verified. Note that the adaptive time step cannot know _a priori_ the stable timestep for collision so ensure that _Post\_fragmentation\_timestep_ is still set appropriately low.

### New Postprocessing Mode: Interior
Specifying _-pp INT_ enables the use of the interior postprocessing mode which keeps the heaviest assembly of the simulation stationary and transforms objects around it. This mode is useful for viewing and analysing collisions, especially those happening inside enclosed volumes.

### Added "In-loop" Postprocessing
By specifying _Postprocess\_in\_loop=ECEF/WIND/INT_ in the **[Options]** TITAN can pre-postprocess iterations as a simulation progresses. This works with smooth interpolant solutions or standard postprocessing.

### Alternate Trajectory Specification Frames
Added the ability to specify an initial state as either an Earth Centred Inertial (ECI) or Earth Centred Earth Fixed (ECEF) state vector. In the **[Trajectory]** section one must specify _Frame=Geodetic/ECI/ECEF_ (default Geodetic) and then...
- ...if using ECEF: _State=X, Y, Z, U, V, W_   (in _m_ and _m/s_)
- ...if using ECI: _Epoch=yyyy/mm/dd HH:MM:SS_ and _State=X, Y, Z, U, V, W_   (in _m_ and _m/s_)
- ...if using Geodetic: The usual Geodetic state as _Altitude=_, _Latitude=_, _Longitude=_, etc.

### Miscellaneous
- Performed some minor optimisation in aerothermo.py
- Fixed a bug causing multi-step integrators to "double-count" certain aero states