### PR TITLE
Addition of Monte Carlo functionality layer

### DIFF
--- a/Aerothermo/aerothermo.py
+++ b/Aerothermo/aerothermo.py
@@ -465,7 +465,7 @@ def compute_low_fidelity_aerothermo(assembly, options, iteration):
         _assembly.aero_index = index
         compute_aerothermodynamics(_assembly, [], index, flow_direction, options)
         compute_aerodynamics(_assembly, [], index, flow_direction, options)
-        if options.pato.flag and options.pato.Ta_bc == "ablation": compute_equilibrium_chemistry(_assembly, options.aerothermo.mixture, index)
+        #if options.pato.flag and options.pato.Ta_bc == "ablation": compute_equilibrium_chemistry(_assembly, options.aerothermo.mixture, index)
         #if options.pato: compute_frozen_chemistry(_assembly, options.aerothermo.mixture)
 
 
@@ -615,7 +615,7 @@ def compute_equilibrium_chemistry(assembly, mixture, p):
 
     #print('chemistry mixture:', mixture)
 
-    mix = mixture_mpp('air5')
+    mix = mixture_mpp(mixture)
 
     nSpecies = mix.nSpecies()
 

--- a/Aerothermo/bloom.py
+++ b/Aerothermo/bloom.py
@@ -99,9 +99,9 @@ def generate_PATO_mesh(options, object_id, bloom):
 
     create_bloom_config(1, bloom, options, path_folder)
 
-    subprocess.run(['python3.10', path+'/Executables/su2_to_gmf.py', '-m' ,options.output_folder + path_folder +input_grid+'.su2','-o',options.output_folder+path_folder+input_grid])
+    subprocess.run(['python', path+'/Executables/su2_to_gmf.py', '-m' ,options.output_folder + path_folder +input_grid+'.su2','-o',options.output_folder+path_folder+input_grid])
     subprocess.run([path+'/Executables/amg_bloom', '-in', options.output_folder+path_folder+input_grid+'.meshb', '-bl-data',options.output_folder+path_folder+"bloom", '-bl-hybrid', '-out', options.output_folder+path_folder+input_grid+'_PL', '-hmsh'])
-    subprocess.run(['python3.10', path+'/Executables/gmf_to_su2.py', '-m', options.output_folder+path_folder+input_grid+'_PL.meshb', '-b', options.output_folder +path_folder+input_grid+'.su2', '-o', options.output_folder+path_folder+output_grid])
+    subprocess.run(['python', path+'/Executables/gmf_to_su2.py', '-m', options.output_folder+path_folder+input_grid+'_PL.meshb', '-b', options.output_folder +path_folder+input_grid+'.su2', '-o', options.output_folder+path_folder+output_grid])
     subprocess.run(['python', path+'/Executables/su2tomsh-amg.py', options.output_folder+path_folder+output_grid+".su2"])
     subprocess.run(['mv', path+'/mesh.msh', options.output_folder+path_folder])
     subprocess.run(['rm', '/'+options.output_folder+path_folder+'*.meshb'])

--- a/Configuration/configuration.py
+++ b/Configuration/configuration.py
@@ -123,6 +123,10 @@ class Dynamics():
 
         #: [ECEF/Geodetic] Frame of specified input state
         self.trajectory_frame = 'geodetic'
+
+        self.trajectory_epoch = '1970/01/01 01:01:01'
+
+        self.trajectory_state = np.zeros(6)
         #: [str] Name of the propagator to be used in the dynamics (options - euler, ).
         self.propagator = propagator
 
@@ -501,6 +505,23 @@ class GRAM():
         # [float] Seconds
         self.seconds = 0.0
 
+class Uncertainty():
+    def __init__(self, yaml_path='./Uncertainty/uq_example.yaml', master_seed = 0, n_procs=1):
+        self.yaml = yaml_path
+        self.prime_seed = master_seed
+        self.n_procs = n_procs
+    
+    def build_quantities(self, path):
+        self.outputs = [name.strip() for name in self.outputs.split(',')] if not self.outputs=='demise_points' else ['Latitude','Longitude','Altitude']
+        self.objects = [name.strip() for name in self.objects.split(',')]
+        for i_obj, obj in enumerate(self.objects):
+            self.stls.append(path+obj)
+            self.objects[i_obj] = obj.rsplit( ".", 1 )[ 0 ]
+            self.quantities[self.stls[i_obj]] = {output : [] for output in self.outputs}
+        filepath = self.qoi_filepath
+        if not os.path.exists(filepath):
+            with open(filepath,'wb') as file: 
+                pickle.dump(self.quantities, file)
 
 class Options():
     """ Options class
@@ -540,6 +561,9 @@ class Options():
         self.freestream = Freestream()
 
         self.planet = planet.ModelPlanet("Earth")
+        
+        self.uncertainty = Uncertainty()
+
         self.vehicle = None
         
         #: [int] Number of dynamic iterations
@@ -1080,6 +1104,7 @@ def read_config_file(configParser, postprocess = "", emissions = ""):
     options.time_fidelity = get_config_value(configParser, options.time_fidelity, 'Options', 'Time_fidelity','float')
     options.write_dense_solutions = get_config_value(configParser, False, 'Options','Dense_solutions', 'boolean' )
     options.postproc_in_loop = get_config_value(configParser, None, 'Options', 'Postprocess_in_loop','str')
+    options.write_object_properties = get_config_value(configParser, False, 'Options', 'Write_object_properties', 'boolean')
     options.time_counter   = 0
 
 
@@ -1253,6 +1278,12 @@ def read_config_file(configParser, postprocess = "", emissions = ""):
         options.collision.mesh_factor = get_config_value(configParser, options.collision.mesh_factor, 'Collision', 'Mesh_factor', 'float')
         options.collision.elastic_factor = get_config_value(configParser, options.collision.elastic_factor, 'Collision', 'Elastic_factor', 'float')
 
+    if configParser.has_section('Uncertainty'):
+        options.uncertainty.n_procs = get_config_value(configParser, options.uncertainty.n_procs, 'Uncertainty', 'Num_cores', 'int')
+        options.uncertainty.prime_seed = get_config_value(configParser, options.uncertainty.prime_seed, 'Uncertainty', 'Seed', 'int')
+        options.uncertainty.yaml = get_config_value(configParser, options.uncertainty.yaml, 'Uncertainty', 'Yaml_path', 'int')
+
+
     output.options_information(options)
 
     if options.load_mesh != True and options.load_state != True:
@@ -1266,6 +1297,9 @@ def read_config_file(configParser, postprocess = "", emissions = ""):
     else:
         #Read the initial trajectory details
         options.dynamics.trajectory_frame = get_config_value(configParser, options.dynamics.trajectory_frame, 'Trajectory', 'Frame', 'str')
+        options.dynamics.trajectory_epoch = get_config_value(configParser, options.dynamics.trajectory_epoch, 'Trajectory', 'Epoch', 'str')
+        options.dynamics.trajectory_state = get_config_value(configParser, '0,0,0,0,0,0', 'Trajectory', 'State', 'str').split(',')
+        options.dynamics.trajectory_state = np.array([float(value) for value in options.dynamics.trajectory_state])
         trajectory = read_trajectory(configParser, options.dynamics.trajectory_frame, options.planet)
 
         if options.load_mesh:

--- a/Geometry/component.py
+++ b/Geometry/component.py
@@ -194,6 +194,13 @@ class PATO():
 
         self.molten = np.zeros(len_facets)
 
+        # NB: Tommy has not very much idea about Bprime at all so its possible this is nonsense
+        # Enthalpy of recovery
+        self.h_r = 2e5 * np.ones(len_facets)
+
+        # Conductivity BC
+        self.rhoeUeCH = 0.3 * np.ones(len_facets)
+
         Path(options.output_folder+'/PATO_'+str(object_id)+'/').mkdir(parents=True, exist_ok=True)
         Path(options.output_folder+'/PATO_'+str(object_id)+'/verification/').mkdir(parents=True, exist_ok=True)
         Path(options.output_folder+'/PATO_'+str(object_id)+'/verification/unstructured_gmsh/').mkdir(parents=True, exist_ok=True)

--- a/Output/output.py
+++ b/Output/output.py
@@ -79,6 +79,7 @@ def write_output_data(titan, options, smooth=False):
         df['Inertia_yy'] = [assembly.inertia[1,1]]
         df['Inertia_yz'] = [assembly.inertia[1,2]]
         df['Inertia_zz'] = [assembly.inertia[2,2]]
+        df['Kinetic_energy'] = assembly.mass * assembly.trajectory.velocity**2
 
         #Attitude properties
         df['Roll'] =     [assembly.roll*180/np.pi]
@@ -147,9 +148,10 @@ def write_output_data(titan, options, smooth=False):
 
         df_temp = pd.DataFrame()
         df_mass = pd.DataFrame()
-        for i, obj in enumerate(assembly.objects):
-            df_temp["Temperature_obj_"+str(i)] = [obj.temperature]
-            df_mass["Mass_obj_"+str(i)] = [obj.mass]
+        if options.write_object_properties:
+            for i, obj in enumerate(assembly.objects):
+                df_temp["Temperature_obj_"+str(i)] = [obj.temperature]
+                df_mass["Mass_obj_"+str(i)] = [obj.mass]
 
         df = pd.concat([df, df_temp], axis = 1)
         df = pd.concat([df, df_mass], axis = 1)

--- a/TITAN.py
+++ b/TITAN.py
@@ -185,6 +185,11 @@ if __name__ == "__main__":
                         type=str,
                         help="simulation postprocess (ECEF, WIND)",
                         metavar="postprocess")
+    parser.add_argument("-MC", "--montecarlo",
+                        dest="n_samples",
+                        type=int,
+                        help = "run a Monte Carlo campaign of N simulations",
+                        metavar="n_samples")
     parser.add_argument("-flt", "--filter",
                         dest="filtername",
                         type=str,
@@ -203,6 +208,13 @@ if __name__ == "__main__":
     postprocess = args.postprocess
     filter_name = args.filtername
     emissions = args.emissions
+
+    if args.n_samples is not None:
+        from Uncertainty import MC_wrapper
+        print()
+        MC_wrapper.run(filename,args.n_samples)
+        exit()
+
     if postprocess and (postprocess.lower()!="wind" and postprocess.lower()!="ecef" and postprocess.lower()!="int"):
         raise Exception("Postprocess can only be WIND, ECEF or INT")
 

--- a/Thermal/pato.py
+++ b/Thermal/pato.py
@@ -27,6 +27,7 @@ from vtk import *
 import glob
 import os
 import re
+import pathlib
 from scipy.spatial import KDTree
 from Material import material as Material
 import pandas as pd
@@ -176,7 +177,7 @@ def write_All_run_init(options, object_id):
         f.write('cd ' + options.output_folder + '/PATO_'+str(object_id)+' \n')
         f.write('cp -r origin.0 0 \n')
         f.write('cd verification/unstructured_gmsh/ \n')
-        f.write('ln -s ' + options.output_folder + '/PATO_'+str(object_id)+'/mesh/mesh.msh \n')
+        f.write('ln -s ' + str(pathlib.Path(options.output_folder).resolve()) + '/PATO_'+str(object_id)+'/mesh/mesh.msh \n')
         f.write('cd ../.. \n')
         f.write('gmshToFoam verification/unstructured_gmsh/mesh.msh \n')
         f.write('mv constant/polyMesh constant/subMat1 \n')
@@ -428,7 +429,7 @@ def write_constant_folder(options, object_id):
             f.write('}\n')
             f.write('Mass {\n')
             f.write('  MassType no; // Solve the semi implicit pressure equation\n')
-            f.write('  createFields ((p volScalarField) (mDotG volVectorField) (mDotGw volScalarField) (mDotVapor volScalarField) (mDotMelt volScalarField));\n')
+            f.write('  createFields ((p volScalarField) (mDotG volVectorField) (mDotGw volScalarField) (mDotVapor volScalarField) (mDotMelt volScalarField) (molten volScalarField));\n')
             f.write('}\n')
             f.write('Energy {\n')
             f.write('  EnergyType PureConduction; // Solve the temperature equation\n')
@@ -613,6 +614,8 @@ def write_origin_folder(options, obj):
             f.write('    (emissivity "4")\n')
             f.write('    (Tbackground "5")\n')
             f.write('    (molten "6")\n')
+            f.write('    (h_r "7")\n')
+            f.write('    (rhoeUeCH "8")\n')
             f.write(');\n')
             f.write('chemistryOn 1;\n')
             f.write('p 101325;\n')
@@ -944,6 +947,41 @@ def write_origin_folder(options, obj):
 
         f.close()
 
+        with open(options.output_folder + '/PATO_'+str(obj.global_ID)+'/origin.0/subMat1/molten', 'w') as f:
+            
+            f.write('/*--------------------------------*- C++ -*----------------------------------*\\ \n')
+            f.write('  =========                 | \n')
+            f.write('  \\\\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox \n')
+            f.write('   \\\\    /   O peration     | Website:  https://openfoam.org \n')
+            f.write('    \\\\  /    A nd           | Version:  7 \n')
+            f.write('     \\\\/     M anipulation  | \n')
+            f.write('\\*---------------------------------------------------------------------------*/ \n')
+            f.write('FoamFile { \n')
+            f.write('  version     2.0; \n')
+            f.write('  format      ascii; \n')
+            f.write('  class       volScalarField; \n')
+            f.write('  location    "1/porousMat"; \n')
+            f.write('  object      molten; \n')
+            f.write('} \n')
+            f.write('// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * // \n')
+            f.write(' \n')
+            f.write('dimensions      [0 0 0 0 0 0 0]; \n')
+            f.write(' \n')
+            f.write('internalField   uniform 0; \n')
+            f.write(' \n')
+            f.write('boundaryField { \n')
+            f.write('  top \n')
+            f.write('  { \n')
+            f.write('    type            calculated; \n')
+            f.write('    value           uniform 0.0; \n')
+            f.write('  } \n')
+            f.write('} \n')
+            f.write(' \n')
+            f.write(' \n')
+            f.write('// ************************************************************************* // \n')
+
+        f.close()
+
     pass
 
 def write_PATO_BC(options, obj, time, conv_heatflux, freestream_temperature):
@@ -978,15 +1016,35 @@ def write_PATO_BC(options, obj, time, conv_heatflux, freestream_temperature):
             f.write(' STRANDID=0, SOLUTIONTIME=0\n')
             f.write(' I=' + str(n_data_points) + ', J=1, K=1, ZONETYPE=Ordered\n')
             f.write(' DATAPACKING=BLOCK\n')
-            f.write(' DT=(DOUBLE DOUBLE DOUBLE DOUBLE)   \n')
-            f.write(np.array2string(x)[1:-1]+' ')
-            f.write(np.array2string(y)[1:-1]+' ')
-            f.write(np.array2string(z)[1:-1]+' ')
-            f.write(np.array2string(conv_heatflux)[1:-1]+' ')
-            f.write(np.array2string(emissivity)[1:-1]+' ')
-            f.write(np.array2string(Tinf)[1:-1]+' ')
+            f.write(' DT=(DOUBLE DOUBLE DOUBLE DOUBLE DOUBLE)   \n ')
+            f.write(np.array2string(x)[1:-1]+' \n')
+            f.write(np.array2string(y)[1:-1]+' \n')
+            f.write(np.array2string(z)[1:-1]+' \n')
+            f.write(np.array2string(conv_heatflux)[1:-1]+' \n')
+            f.write(np.array2string(emissivity)[1:-1]+' \n')
+            f.write(np.array2string(Tinf)[1:-1]+' \n')
 
         if options.pato.Ta_bc == "ablation":
+
+            # f.write('TITLE = "vol-for-blayer.fu"\n')
+            # f.write('VARIABLES = '
+            #         '"xw (m)" "yw (m)" "zw (m)" '
+            #         '"qConv (W/m^2)" "emissivity (-)" "Tbackground (K)" '
+            #         '"molten (-)" "h_r (J/kg)" "rhoeUeCH (kg/m^2/s)"\n')
+
+            # f.write(f'ZONE T="zone 1", STRANDID=0, SOLUTIONTIME=0, '
+            #         f'I={n_data_points}, J=1, K=1, ZONETYPE=Ordered, '
+            #         'DATAPACKING=BLOCK, '
+            #         'DT=(DOUBLE DOUBLE DOUBLE DOUBLE DOUBLE DOUBLE DOUBLE DOUBLE DOUBLE)\n')
+
+            # arrays = [
+            #     x, y, z, conv_heatflux,
+            #     emissivity, Tinf,
+            #     obj.pato.molten, obj.pato.h_r, obj.pato.rhoeUeCH
+            # ]
+            # assert np.all([len(arr)==n_data_points for arr in arrays])
+            # for arr in arrays:
+            #     f.write(" ".join(str(v) for v in arr) + "\n")
 
             f.write('TITLE     = "vol-for-blayer.fu"\n')
             f.write('VARIABLES = \n')
@@ -997,18 +1055,34 @@ def write_PATO_BC(options, obj, time, conv_heatflux, freestream_temperature):
             f.write('"emissivity (-)"\n')
             f.write('"Tbackground (K)"\n')
             f.write('"molten (-)"\n')
-            f.write('ZONE T="zone 1"\n')
+            f.write('"h_r (J/kg)"\n')
+            f.write('"rhoeUeCH (kg/m^2/s)"\n')
+            f.write(' ZONE T="zone 1"\n')
             f.write(' STRANDID=0, SOLUTIONTIME=0\n')
             f.write(' I=' + str(n_data_points) + ', J=1, K=1, ZONETYPE=Ordered\n')
             f.write(' DATAPACKING=BLOCK\n')
-            f.write(' DT=(DOUBLE DOUBLE DOUBLE DOUBLE)   \n')
-            f.write(np.array2string(x)[1:-1]+' ')
-            f.write(np.array2string(y)[1:-1]+' ')
-            f.write(np.array2string(z)[1:-1]+' ')
-            f.write(np.array2string(conv_heatflux)[1:-1]+' ')
-            f.write(np.array2string(emissivity)[1:-1]+' ')
-            f.write(np.array2string(Tinf)[1:-1]+' ')
-            f.write(np.array2string(obj.pato.molten)[1:-1]+' ')
+            f.write(' DT=(DOUBLE DOUBLE DOUBLE DOUBLE DOUBLE DOUBLE DOUBLE DOUBLE DOUBLE)   \n')
+            print(np.nonzero(np.array(np.array(obj.pato.molten, dtype=bool),dtype=int)))
+            arrays = [
+                x, y, z, conv_heatflux,
+                emissivity, Tinf,
+                np.array(np.array(obj.pato.molten, dtype=bool),dtype=int), obj.pato.h_r, obj.pato.rhoeUeCH
+            ]
+            assert np.all([len(arr)==n_data_points for arr in arrays])
+            for arr in arrays:
+                f.write(" "+"\n ".join(str(v) for v in arr)+'\n')
+
+            # f.write(" "+" ".join(str(v)))
+            # f.write(np.array2string(x)[1:-1]+'\n ')
+            # f.write(np.array2string(y)[1:-1]+'\n ')
+            # f.write(np.array2string(z)[1:-1]+'\n ')
+            # f.write(np.array2string(conv_heatflux)[1:-1]+'\n ')
+            # f.write(np.array2string(emissivity)[1:-1]+'\n ')
+            # f.write(np.array2string(Tinf)[1:-1]+'\n ')
+            # f.write(np.array2string(obj.pato.molten)[1:-1]+'\n ')
+            # f.write(np.array2string(obj.pato.h_r)[1:-1]+'\n ')
+            # f.write(np.array2string(obj.pato.rhoeUeCH)[1:-1]+'\n ')
+
 
     f.close()
 
@@ -1450,7 +1524,7 @@ def postprocess_PATO_solution(options, obj, time_to_read):
 	?????????????????????????
     """ 
 
-    if options.pato.Ta_bc == 'ablation': postprocess_mass_inertia(obj, options, time_to_read)
+    #if options.pato.Ta_bc == 'ablation': postprocess_mass_inertia(obj, options, time_to_read)
 
     path = options.output_folder+"/PATO_"+str(obj.global_ID)+"/"
 
@@ -1504,7 +1578,7 @@ def postprocess_PATO_solution(options, obj, time_to_read):
     if options.pato.Ta_bc == "ablation":
         obj.pato.mDotVapor = mDotVapor_cell[mapping]
         obj.pato.mDotMelt = mDotMelt_cell[mapping]
-        obj.pato.molten[obj.temperature == obj.material.meltingTemperature] = 1
+        obj.pato.molten[obj.temperature >= obj.material.meltingTemperature] = 1
 
 def postprocess_mass_inertia(obj, options, time_to_read):
 

--- a/Uncertainty/MC_wrapper.py
+++ b/Uncertainty/MC_wrapper.py
@@ -1,0 +1,131 @@
+#
+# Copyright (c) 2023 TITAN Contributors (cf. AUTHORS.md).
+#
+# This file is part of TITAN 
+# (see https://github.com/strath-ace/TITAN).
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+
+import configparser
+import concurrent.futures
+import numpy as np
+import pathlib
+import copy
+import yaml
+try: from yaml import CLoader as Loader
+except: from yaml import Loader
+
+from TITAN import loop
+from Configuration.configuration import read_config_file
+from Uncertainty.utils import UQMapper, report_outputs_from_csv, collate_QoI
+from Dynamics.propagation import construct_state_vector
+
+def run(filename,n_samples):
+    n_samples = int(n_samples)
+    configParser = configparser.RawConfigParser()   
+    configFilePath = filename.lstrip()
+    configParser.read(configFilePath)
+
+
+    base_options, base_titan = read_config_file(configParser,'')
+    base_folder = base_options.output_folder
+    prime_seed = base_options.uncertainty.prime_seed
+
+    seedlist = np.random.RandomState(prime_seed).random_integers(0,2**32-1,n_samples)
+
+    base_titan.uq_mapper = UQMapper(base_titan, base_options)
+    
+    if base_options.collision.flag: # Can't serialise collision data
+        for _assembly in base_titan.assembly: _assembly.collision = None
+
+    if base_options.uncertainty.n_procs>1:
+        with concurrent.futures.ProcessPoolExecutor(base_options.uncertainty.n_procs) as executor:
+            output_futures = [executor.submit(wrapper,base_titan,base_options,i_sample,seed) for i_sample, seed in enumerate(seedlist)]
+
+            for i_sim, f in enumerate(concurrent.futures.as_completed(output_futures)):
+                if f._exception:
+                    print('Error on result number {}: {}'.format(i_sim,f.exception()))
+                else:
+                    print('Finished sim: '+str(i_sim+1)+' ('+str(round(100*(i_sim+1)/n_samples,4))+'%)')
+            concurrent.futures.wait(output_futures)
+    else:
+
+        for i_sample, seed in enumerate(seedlist): 
+            new_titan = copy.deepcopy(base_titan)
+            new_options = copy.deepcopy(base_options)
+            wrapper(new_titan, new_options, i_sample, seed)
+            del new_titan, new_options
+    collate_QoI(seedlist, base_folder, prime_seed)
+    
+def wrapper(titan, options, i_sample, seed):
+    print('Starting run {} seed [{}]'.format(i_sample, str(seed).rjust(10,'0')))
+    options.output_folder += '/Campaign_'+str(options.uncertainty.prime_seed)+'/MC_' + str(i_sample)
+    options.clean_up_folders()
+    options.create_output_folders()
+    component_list = []
+    for _assembly in titan.assembly: 
+        construct_state_vector(_assembly)
+        [component_list.append(comp.name) for comp in _assembly.objects]
+    state_info = titan.uq_mapper.map_from_seed(seed, titan, options)
+    write_datafile(options.output_folder, i_sample, state_info)
+    options.plot = True if i_sample % round(2*options.uncertainty.n_procs) == 0 else False
+    options.filepath = ''
+    try:
+        loop(options,titan)
+
+        with open(str(pathlib.Path(options.uncertainty.yaml).resolve()),'r') as f: 
+            output_dict = yaml.load(f,Loader)['outputs']
+        output_names, output_values = report_outputs_from_csv(options.output_folder, output_dict, component_list)
+
+    except Exception as e: 
+        log_error(options.output_folder, seed, e)
+        raise e
+    
+    update_datafile(options.output_folder, seed, output_names, output_values)
+
+    return output_names, output_values
+
+def write_datafile(directory, i_sample, state_info):
+    with open(directory + '/MCdata_'+str(state_info['seed']).rjust(10,'0'), 'w') as f:
+        f.write('''__________________________________________________________________________________
+__________________________________________________________________________________
+          _        $$$$####| $$##| $$$###| //$#\\\\  $#|   $#|      $#| $#| //$#\\\\ 
+        _-#-_         $#|     $#|    $#|   $#| $#| $#\\\\  $#|      $#| $#| $#| $#|  
+       /#####\\        $#|     $#|    $#|   $$$###| $#| \\\\$#| $#|  $#| $#| $#| $#|
+     /### ? ###\\      $#|     $#|    $#|   $#| $#| $#|   $#|      $#| $#| $#| $#|
+__--#############--___$#|____$$##|___$#|___$#|_$#|_$#|___$#|______\\\\$#//__\\\\$#//
+_____________________________(Still_in_development!)________________________\\\\$#|_
+
+''')
+        f.write('RUN | {} | SEED | {} |\n'.format(i_sample, str(state_info['seed']).rjust(10,'0')))
+        i_param = 0
+        for param, value in state_info.items():
+            if param=='seed': continue
+            f.write('PARAMETER #{} - {}:{}\n'.format(i_param, param, value))
+            i_param+=1
+        f.write('\n----------------------------------------------------------------------------------\n\n')
+
+def update_datafile(directory, seed, output_names, output_values):
+     with open(directory + '/MCdata_'+str(seed).rjust(10,'0'), 'a') as f:
+         if len(output_names)<1: f.write('NO OUTPUT')
+         i_out = 0
+         for name, value in zip(output_names, output_values):
+             f.write('OUTPUT #{} - {}:{}\n'.format(i_out, name, value))
+             i_out+=1
+
+def log_error(directory, seed, error):
+    with open(directory + '/MCdata_'+str(seed).rjust(10,'0'), 'a') as f:
+        f.write('ERROR - NO OUTPUT GENERATED\n')
+        f.write('Exception: {}'.format(error))

--- a/Uncertainty/UQ_parameter_handbook.md
+++ b/Uncertainty/UQ_parameter_handbook.md
@@ -1,0 +1,61 @@
+## TITAN Uncertainty Propagation: Parameter Handbook
+*24.11.2025* 
+  
+This handbook details all exposed variables that can be controlled using a *.yaml* file (see associated example in this folder).  Parametres are sorted by options section and given in the following format (note names are case sensitive)...  
+*{**NAME** [data type] : Brief description}*
+
+## Trajectory
+ - **altitude** [metres]        : Initial height above body
+ - **gamma** [radians]          : Initial flight path angle value.
+ - **chi** [radians]            : Initial heading angle value.
+ - **velocity** [metres/second] : Initial velocity value.
+ - **latitude** [radians]       : Initial latitude value. 
+ - **longitude** [radians]      : Initial longitude value.
+ **OR**
+ - **ECEF_x** [metres/second] : Initial x position in ECEF frame
+ - **ECEF_y** [metres/second] : Initial y position in ECEF frame
+ - **ECEF_z** [metres/second] : Initial z position in ECEF frame
+ - **ECEF_u** [metres/second] : Initial u velocity in ECEF frame
+ - **ECEF_v** [metres/second] : Initial v velocity in ECEF frame
+ - **ECEF_w** [metres/second] : Initial w velocity in ECEF frame
+ **OR**
+ - **ECI_x** [metres/second]    : Initial x position in ECI frame
+ - **ECI_y** [metres/second]    : Initial y position in ECI frame
+ - **ECI_z** [metres/second]    : Initial z position in ECI frame
+ - **ECI_u** [metres/second]    : Initial u velocity in ECI frame
+ - **ECI_v** [metres/second]    : Initial v velocity in ECI frame
+ - **ECI_w** [metres/second]    : Initial w velocity in ECI frame
+ - **ECI_epoch_UNIX** [seconds] : ECI initial time (seconds since Jan 1 1970 00:00:00)
+
+## Attitude
+ - **omega_roll** [radians/second]  : Initial rotation rate about body roll (x) axis.
+ - **omega_pitch** [radians/second] : Initial rotation rate about body pitch (y) axis.
+ - **omega_yaw** [radians/second]   : Initial rotation rate about body yaw (z) axis.
+
+ - **quat_x** [0-1] : Initial body-frame quaterion x component
+ - **quat_y** [0-1] : Initial body-frame quaterion y component
+ - **quat_z** [0-1] : Initial body-frame quaterion z component
+ - **quat_w** [0-1] : Initial body-frame quaterion w component
+  **OR**
+ - **roll** [radians] : Initial rotation about wind roll (x) axis.
+ - **aoa** [radians]  : Initial rotation about wind pitch (y) axis.
+ - **slip** [radians] : Initial rotation about wind yaw (z) axis.
+
+## Assembly
+**Note if assembly fragments inertia tensor will be recalculated (these parameters will be discarded)**
+- **Ixx** [kilogram/metre^2] : Moment of inertia about roll (x) axis
+- **Iyy** [kilogram/metre^2] : Moment of inertia about pitch (y) axis
+- **Izz** [kilogram/metre^2] : Moment of inertia about yaw (z) axis
+- **Ixy** [kilogram/metre^2] : x-y product of inertia
+- **Iyz** [kilogram/metre^2] : y-z product of inertia
+- **Ixz** [kilogram/metre^2] : x-z product of inertia
+
+## Aerothermo
+- **catalycity** [0-1] : Surface catalytic efficiency/recombination, note "material" catalycity must be disabled
+
+## Objects
+Uncertain parameters assigned to objects should have the object name after the double underscore (e.g. 'trigger__Cube_A.stl')
+- **trigger__** [float]      : The fragmentation trigger of the object, units determined by how the trigger is set
+- **temperature__** [Kelvin] : The initial temperature of the object
+**(Variables exposed by the in-development explosion model)**
+- **energy__** [J] : Available energy of explosion

--- a/Uncertainty/mappings.py
+++ b/Uncertainty/mappings.py
@@ -1,0 +1,190 @@
+#
+# Copyright (c) 2023 TITAN Contributors (cf. AUTHORS.md).
+#
+# This file is part of TITAN 
+# (see https://github.com/strath-ace/TITAN).
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+from scipy.stats import *
+from scipy.spatial.transform import Rotation
+import numpy as np
+## Lot of messy mapping information here to enable uq parameters to be easily exposed
+
+## Addresses are of form 'access;pointer,access;pointer,etc'
+def assembly_address(index): return 'TITAN,attr;assembly,index;'+str(index)
+
+def trajectory_address(index): return assembly_address(index) + ',attr;trajectory'
+
+def component_address(assembly_index, component_index): 
+    return assembly_address(assembly_index) + ',attr;objects,index;'+str(component_index)
+
+def option_aero_address(assembly_index): return 'OPTIONS,attr;aerothermo'
+
+def option_traj_address(assembly_index): return 'OPTIONS,attr;dynamics'
+
+def get_component_index_from_name(name, titan, assembly_index=0):
+    for i_component, component in enumerate(titan.assembly[assembly_index].objects):
+        if name in component.name: return i_component
+    raise Exception('Could not find component {} in assembly {}'.format(name, assembly_index))
+
+# Here parameters are mapped to relevant objects
+library_addresses = {assembly_address    : ['ECEF_x','ECEF_y','ECEF_z','ECEF_u','ECEF_v','ECEF_w', 'quat_w', 
+                                            'quat_x', 'quat_y','quat_z','omega_roll', 'omega_pitch', 'omega_yaw', 
+                                            'roll', 'aoa','slip','Ixx', 'Iyy', 'Izz', 'Ixy', 'Iyz', 'Ixz'],
+                     trajectory_address  : ['altitude','gamma','chi','velocity','latitude','longitude'],
+                     component_address   : ['trigger__','temperature__'],
+                     option_aero_address : ['catalycity'],
+                     option_traj_address : ['ECI_x','ECI_y','ECI_z','ECI_u','ECI_v','ECI_w','ECI_epoch_UNIX']}
+
+
+# Here parameters are mapped to relevant attributes (of mapped objects)
+library_assignments = {'ECEF_x'         : ['state_vector', 0],
+                       'ECEF_y'         : ['state_vector', 1],
+                       'ECEF_z'         : ['state_vector', 2],
+                       'ECEF_u'         : ['state_vector', 3],
+                       'ECEF_v'         : ['state_vector', 4],
+                       'ECEF_w'         : ['state_vector', 5],
+                       'quat_x'         : ['state_vector', 6],
+                       'quat_y'         : ['state_vector', 7],
+                       'quat_z'         : ['state_vector', 8],
+                       'quat_w'         : ['state_vector', 9],
+                       'omega_roll'     : ['state_vector', 10],
+                       'omega_pitch'    : ['state_vector', 11],
+                       'omega_yaw'      : ['state_vector', 12],
+                       'altitude'       : ['altitude'],
+                       'gamma'          : ['gamma'],
+                       'chi'            : ['chi'],
+                       'velocity'       : ['velocity'],
+                       'latitude'       : ['latitude'],
+                       'longitude'      : ['longitude'],
+                       'ECI_x'          : ['trajectory_state', 0],
+                       'ECI_y'          : ['trajectory_state', 1],
+                       'ECI_z'          : ['trajectory_state', 2],
+                       'ECI_u'          : ['trajectory_state', 3],
+                       'ECI_v'          : ['trajectory_state', 4],
+                       'ECI_w'          : ['trajectory_state', 5],                       
+                       'roll'           : ['roll'],
+                       'aoa'            : ['aoa'],
+                       'slip'           : ['slip'],
+                       'trigger__'      : ['trigger_value'],
+                       'temperature__'  : ['temperature'],
+                       'Ixx'            : ['inertia', [0,0]],
+                       'Iyy'            : ['inertia', [1,1]],
+                       'Izz'            : ['inertia', [2,2]],
+                       'Ixy'            : ['inertia', [0,1]],
+                       'Iyz'            : ['inertia', [1,2]],
+                       'Ixz'            : ['inertia', [0,2]],
+                       'ECI_epoch_UNIX' : ['trajectory_epoch'],
+                       'catalycity'     : ['cat_rate']
+                       }
+
+def library_check(name):
+    try: assert name in list(library_assignments.keys())
+    except: 
+        raise Exception('Could not find parameter {} in list, please check the UQ handbook'.format(name))
+
+def state_vector_callback(titan, options, assem_ids):
+    from Dynamics.propagation import construct_state_vector
+    for i_assem in assem_ids: construct_state_vector(titan.assembly[i_assem])
+
+def dynamic_attributes_callback(titan, options, assem_ids):
+    from Dynamics.propagation import update_dynamic_attributes
+    for i_assem in assem_ids: update_dynamic_attributes(titan.assembly[i_assem],
+                                                        titan.assembly[i_assem].state_vector,
+                                                        options,
+                                                        force=True)
+
+def ECI_position_callback(titan, options, assem_ids):
+    import pymap3d
+    import datetime as dt
+    epoch = options.dynamics.trajectory_epoch
+    if isinstance(epoch, str):
+        epoch = dt.datetime.strptime(epoch,'%Y/%m/%d %H:%M:%S')
+    elif isinstance(epoch, float) or isinstance(epoch, int): epoch = dt.datetime.fromtimestamp(epoch)
+    for i_assem in assem_ids:
+        state = options.dynamics.trajectory_state
+        state[:3] = pymap3d.eci2ecef(state[0],state[1],state[2],time=epoch)
+        rotMatrix = np.transpose([pymap3d.eci2ecef(1,0,0,epoch),
+                                  pymap3d.eci2ecef(0,1,0,epoch),
+                                  pymap3d.eci2ecef(0,0,1,epoch)])
+        state[3:] = rotMatrix @ state[3:] -np.cross([0,0,options.planet.omega()],state[:3])
+        titan.assembly[i_assem].state_vector[:6] = state
+    dynamic_attributes_callback(titan, options, assem_ids)
+
+def orientation_callback(titan, options, assem_ids):
+    from Dynamics.dynamics import compute_quaternion
+    for i_assem in assem_ids: 
+        compute_quaternion(titan.assembly[i_assem])
+        titan.assembly[i_assem].state_vector[6:10] = titan.assembly[i_assem].quaternion
+    state_vector_callback(titan, options, assem_ids)
+
+
+def symmetrize_inertia_callback(titan, options, assem_ids):
+    for i_assem in assem_ids:
+        titan.assembly[i_assem].inertia[1,0] = titan.assembly[i_assem].inertia[0,1]
+        titan.assembly[i_assem].inertia[2,0] = titan.assembly[i_assem].inertia[0,2]
+        titan.assembly[i_assem].inertia[2,1] = titan.assembly[i_assem].inertia[1,2]
+
+callbacks = {state_vector_callback       : ['altitude','latitude','longitude','gamma','chi','velocity'],
+             ECI_position_callback       : ['ECI_x','ECI_y','ECI_z','ECI_u','ECI_v','ECI_w','ECI_epoch_UNIX'],
+             dynamic_attributes_callback : ['ECEF_x','ECEF_y','ECEF_z','ECEF_u','ECEF_v','ECEF_w', 'quat_w',
+                                            'quat_x','quat_y','quat_z','omega_roll','omega_pitch','omega_yaw'],
+             orientation_callback        : ['chi','gamma','roll','aoa','slip','latitude','longitude'],
+             symmetrize_inertia_callback : ['Ixy','Iyz','Ixz']}
+
+## Valid classes for the distribution have to...
+#  ...accept (even a dummy) input
+#  ...have the attribute random_state
+#  ...have the method rvs()
+class quat_rotation():
+    def __init__(self, d=3):
+        self.d = 3
+        self.random_state = None
+    def rvs(self, n=1):
+        quat = Rotation.random(num=n, random_state=self.random_state).as_quat()
+        return quat[0]
+
+# Sometimes extensibility ain't pretty
+available_distris = {'alpha':alpha,'anglit':anglit,'arcsine':arcsine,'argus':argus,'beta':beta,'betaprime':betaprime,
+               'bradford':bradford,'burr':burr,'burr12':burr12,'cauchy':cauchy,'chi':chi,'chi2':chi2,'cosine':cosine,
+               'crystalball':crystalball,'dgamma':dgamma,'dweibull':dweibull,'erlang':erlang,'expon':expon,
+               'exponnorm':exponnorm,'exponweib':exponweib,'exponpow':exponpow,'f':f,'fatiguelife':fatiguelife,
+               'fisk':fisk,'foldcauchy':foldcauchy,'foldnorm':foldnorm,'genlogistic':genlogistic,'gennorm':gennorm,
+               'genpareto':genpareto,'genexpon':genexpon,'genextreme':genextreme,'gausshyper':gausshyper,'gamma':gamma,
+               'gengamma':gengamma,'genhalflogistic':genhalflogistic,'genhyperbolic':genhyperbolic,
+               'geninvgauss':geninvgauss,'gibrat':gibrat,'gompertz':gompertz,'gumbel_r':gumbel_r,'gumbel_l':gumbel_l,
+               'halfcauchy':halfcauchy,'halflogistic':halflogistic,'halfnorm':halfnorm,'halfgennorm':halfgennorm,
+               'hypsecant':hypsecant,'invgamma':invgamma,'invgauss':invgauss,'invweibull':invweibull,
+               'johnsonsb':johnsonsb,'johnsonsu':johnsonsu,'kappa4':kappa4,'kappa3':kappa3,'ksone':ksone,'kstwo':kstwo,
+               'kstwobign':kstwobign,'laplace':laplace,'laplace_asymmetric':laplace_asymmetric,'levy':levy,
+               'levy_l':levy_l,'levy_stable':levy_stable,'logistic':logistic,'loggamma':loggamma,'loglaplace':loglaplace,
+               'lognorm':lognorm,'loguniform':loguniform,'lomax':lomax,'maxwell':maxwell,'mielke':mielke,'moyal':moyal,
+               'nakagami':nakagami,'ncx2':ncx2,'ncf':ncf,'nct':nct,'norm':norm,'normal':norm,'norminvgauss':norminvgauss,
+               'pareto':pareto,'pearson3':pearson3,'powerlaw':powerlaw,'powerlognorm':powerlognorm,'powernorm':powernorm,
+               'rdist':rdist,'rayleigh':rayleigh,'rice':rice,'recipinvgauss':recipinvgauss,'semicircular':semicircular,
+               'skewcauchy':skewcauchy,'skewnorm':skewnorm,'studentized_range':studentized_range,'t':t,
+               'trapezoid':trapezoid,'triang':triang,'truncexpon':truncexpon,'truncnorm':truncnorm,
+               'truncpareto':truncpareto,'truncweibull_min':truncweibull_min,'tukeylambda':tukeylambda,
+               'uniform':uniform,'vonmises':vonmises,'vonmises_line':vonmises_line,'wald':wald,'weibull_min':weibull_min,
+               'weibull_max':weibull_max,'wrapcauchy':wrapcauchy, 'multivariate_normal':multivariate_normal,
+               'matrix_normal':matrix_normal,'dirichlet':dirichlet,'wishart':wishart,'invwishart':invwishart,
+               'multinomial':multinomial,'special_ortho_group':special_ortho_group,'ortho_group':ortho_group,
+               'unitary_group':unitary_group,'random_correlation':random_correlation,'multivariate_t':multivariate_t,
+               'multivariate_hypergeom':multivariate_hypergeom,'random_table':random_table,
+               'uniform_direction':uniform_direction,'bernoulli':bernoulli,'betabinom':betabinom,'binom':binom,
+               'boltzmann':boltzmann,'dlaplace':dlaplace,'geom':geom,'hypergeom':hypergeom,'logser':logser,
+               'nbinom':nbinom,'nchypergeom_fisher':nchypergeom_fisher,'nchypergeom_wallenius':nchypergeom_wallenius,
+               'nhypergeom':nhypergeom,'planck':planck,'poisson':poisson,'randint':randint,'skellam':skellam,
+               'yulesimon':yulesimon,'zipf':zipf,'zipfian':zipfian, 'quat_rotation':quat_rotation}

--- a/Uncertainty/uq_example.yaml
+++ b/Uncertainty/uq_example.yaml
@@ -1,0 +1,43 @@
+## All UQ files must have 3 top level categories, parameters, distributions and outputs. 
+
+## Parameters must point to a single float value based upon the UQ_library and have a parameter code of the form...
+## [assembly_index (usually 0), distribution_index, index_in_distribution]
+
+## Distributions can be any continuous scipy.stats uni/multivariate distribution with necessary kwargs given
+## additionally the some special functions exist such as quat_rotation(d=4) for sampling unit quaternions
+
+## Outputs should be the names of outputs from data.csv and the list of objects to inspect
+## Can specify 'all' for all objects or 'survivors' for only objects that reach ground
+## Bonus options for outputs are as follows
+# - outputs:risk   -> report Altitude, Latitude, Longitude, Velocity, Mass, Kinetic_energy and Lref for all surviving fragment assemblies
+# - outputs:demise -> report Altitude, Mass, Temperature for all objects
+parameters:
+  ECEF_x: [0,0,0]
+  ECEF_y: [0,0,1]
+  ECEF_z: [0,0,2]
+  trigger__Joint.stl: [0,1,0]
+  quat_x: [0,2,0]
+  quat_y: [0,2,1]
+  quat_z: [0,2,2]
+  quat_w: [0,2,3]
+ 
+
+distributions:
+  0:
+    multivariate_normal:
+      mean: [-6040000, -6250000, -2330000]
+      cov: 
+        - [30625, 0,     0]
+        - [0,     30625, 0]
+        - [0,     0,     30625]
+  1: 
+    uniform:
+      loc: 73000
+      scale: 5000
+  2: 
+    quat_rotation:
+      d: 4
+
+outputs: 
+  Mass: Cube_A.stl
+  Altitude: Cube_B.stl

--- a/Uncertainty/utils.py
+++ b/Uncertainty/utils.py
@@ -1,0 +1,236 @@
+#
+# Copyright (c) 2023 TITAN Contributors (cf. AUTHORS.md).
+#
+# This file is part of TITAN 
+# (see https://github.com/strath-ace/TITAN).
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+import numpy as np
+import yaml
+import pandas as pd
+from collections.abc import MutableSequence
+import pathlib
+try: from yaml import CLoader as Loader
+except: from yaml import Loader
+
+from Uncertainty import mappings as ma
+class UQMapper(MutableSequence):
+    ## Once approprUQ Mapper
+    def __init__(self, titan, options):
+        self.parameters = []
+        self.samplers = []
+        self.parse_uq_yaml(titan, options.uncertainty.yaml)
+        self.callback_flags   = {}
+        self.output_dict     = None
+        for key in ma.callbacks.keys(): self.callback_flags[key] = False
+
+    def __getitem__(self, idx):
+        return self.parameters[idx]
+
+    def __setitem__(self, idx, parameter_data):
+        try: 
+            self.parameters[idx] = UQMapObject(*parameter_data)
+            self.parameters[idx].id = idx
+        except Exception as e: 
+            raise Exception('Error setting UQ parameter {} with error: {}'.format(idx,e))
+
+    def __delitem__(self, idx):
+        del self.parameters[idx]
+
+    def __len__(self):
+        return len(self.parameters)
+
+    def insert(self, idx, parameter_data):
+        try: 
+            self.parameters.insert(idx,UQMapObject(*parameter_data))
+            for i_param, param in enumerate(self.parameters): param.id = i_param
+        except Exception as e: 
+            raise Exception('Error setting UQ parameter {} with error: {}'.format(idx,e))
+        
+    def parse_uq_yaml(self, titan, filepath):
+        with open(str(pathlib.Path(filepath).resolve()),'r') as f: uq_yaml = yaml.load(f,Loader)
+
+        parameters = uq_yaml['parameters']
+        distributions_dict = uq_yaml['distributions']
+        self.output_dict = uq_yaml['outputs']
+        for param, code in parameters.items():
+            comp_check = [comp_param in param for comp_param in ma.library_addresses[ma.component_address]]
+            if np.any(comp_check):
+                parameter_type = ma.library_addresses[ma.component_address][comp_check.index(True)]
+                component_name = param.split(parameter_type)[-1]
+                component_index = ma.get_component_index_from_name(component_name,titan,code[0])
+                address = ma.component_address(code[0],component_index)
+                assignment = ma.library_assignments[parameter_type]
+            else:
+                ma.library_check(param)
+                for section, sec_attrs in ma.library_addresses.items():
+                    if param in sec_attrs: 
+                        address = section(code[0])
+                        assignment = ma.library_assignments[param]
+                        break
+            callback_flags = [param in cb for cb in list(ma.callbacks.values())]
+            self.append([param, address, assignment, code, callback_flags])
+
+        for i_distri, distri in distributions_dict.items():
+            distri_name = list(distri.keys())[0]
+            if distri_name not in ma.available_distris.keys(): 
+                raise Exception('Could not find distribution {}'.format(distri_name))
+            self.samplers.append(ma.available_distris[distri_name](**distri[distri_name]))
+
+
+    def map_from_seed(self, seed, titan, options):
+        self.state_info = {}
+        self.state_info['seed'] = seed
+        titan.rng = np.random.RandomState(seed)
+        sample_out = []
+        assem_ids = [[] for _ in range(len(self.callback_flags))]
+
+        for sam in self.samplers:
+            sam.random_state = titan.rng
+            sample_out.append(np.atleast_1d(sam.rvs()))
+
+        for param in self.parameters:
+
+            param.assign(sample_out[param.code[1]][param.code[2]], titan, options)
+            self.state_info[param.name] = sample_out[param.code[1]][param.code[2]]
+
+            i_cb = 0
+            for do_cb, cb in zip(param.callback, list(self.callback_flags.keys())): 
+                if do_cb: 
+                    self.callback_flags[cb] = True
+                    assem_ids[i_cb].append(param.code[0])
+                i_cb += 1
+        i_cb = 0
+        for func, flag in self.callback_flags.items():
+            if flag: func(titan, options, np.unique(assem_ids[i_cb]))
+            i_cb += 1
+
+        return self.state_info
+            
+class UQMapObject():
+    def __init__(self, param_name, param_object, param_assign_loc, code, callback = None):
+        self.name = param_name
+        self.assign_obj = param_object
+        self.assign_location = param_assign_loc
+        self.id = -1
+        self.callback = callback
+        self.code = code
+    
+    def resolve_object(self, titan, options):
+        if isinstance(self.assign_obj, str):
+            address_steps = self.assign_obj.split(',')
+            return_obj = titan if 'titan' in address_steps[0].lower() else options
+            for step in address_steps[1:]:
+                instructions = step.split(';')
+                match instructions[0]:
+                    case 'attr': return_obj = getattr(return_obj, instructions[1])
+                    case 'index': return_obj = return_obj[int(instructions[1])]
+                    case 'key': return_obj = return_obj[instructions[1]]
+            self.assign_obj =  return_obj
+    
+    def assign(self, value, titan, options):
+        self.resolve_object(titan,options)
+        if len(self.assign_location)>1: 
+            new_value = getattr(self.assign_obj,self.assign_location[0])
+            new_value[self.assign_location[1]] = value
+        else: new_value = value
+        setattr(self.assign_obj,self.assign_location[0], new_value)
+
+def report_outputs_from_csv(output_folder, output_dict, all_components, write=True):
+    data = pd.read_csv(output_folder+'/Data/data.csv')
+    assembly_data = pd.read_csv(output_folder+'/Data/data_assembly.csv')
+    geo_path = all_components[0].rsplit('/', maxsplit=1)[0]+'/'
+    name_list = []
+    quantity_map = {}
+
+    if output_dict == 'demise':
+        quantities = ['Altitude','Mass','Tmax']
+        component_map = get_component_map(assembly_data, all_components)
+        for quant in quantities: quantity_map[quant] = component_map
+
+    elif output_dict == 'risk':
+        quantities = ['Altitude','Latitude','Longitude','Velocity','Mass', 'Kinetic_energy','Lref']
+        component_map = get_survivors_map(data, assembly_data)
+        for quant in quantities: quantity_map[quant] = component_map
+
+    else: 
+        for quant, component_list in output_dict.items():
+            if isinstance(component_list, str):
+                if component_list=='all':
+                    component_map = get_component_map(assembly_data, all_components)
+
+                elif component_list=='survivors':
+                    component_map = get_survivors_map(data, assembly_data)
+
+                else: 
+                    component_map = get_component_map(assembly_data, [geo_path+component_list])
+
+            elif isinstance(component_list, list): 
+                comp_paths = [geo_path+comp for comp in component_list]
+                component_map = get_component_map(assembly_data, comp_paths)
+
+            else: 
+                raise Exception('Could not process {} as a component list'.format(component_list))
+            
+            quantity_map[quant] = component_map
+    
+    last_data = data.sort_values('Iter',ascending=False)[['Assembly_ID']+list(quantity_map.keys())]
+    last_data = last_data.drop_duplicates(subset='Assembly_ID')
+
+    header = []
+    values = []
+    for quant, component_map in quantity_map.items():
+        for component_path, assembly_id in component_map.items():
+            comp_name = component_path.rsplit('/',maxsplit=1)[1].rsplit('.',maxsplit=1)[0]
+            value = float(last_data[last_data['Assembly_ID']==assembly_id][quant].iloc[0])
+            header.append(quant + '_' + comp_name)
+            values.append(str(value))
+    if write:
+        str_header = ','.join(header)+'\n'
+        str_values = ','.join(values)+'\n'
+        with open(output_folder+'/QoI.csv','w') as f:
+            f.write(str_header)
+            f.write(str_values)
+    return header, values
+
+def get_survivors_map(data, assembly_data, filter_alt=1000):
+    last_obj_data = assembly_data.sort_values('Iter',ascending=False).drop_duplicates(subset='Obj_name')
+    last_obj_data = last_obj_data[['Assembly_ID','Obj_name']]
+    alt_data = data[['Iter', 'Assembly_ID', 'Altitude']]
+
+    survivor_assembly_ids = alt_data[alt_data['Altitude']<filter_alt]['Assembly_ID']
+    survivor_assembly_ids = pd.unique(survivor_assembly_ids)
+
+    survivors = last_obj_data[last_obj_data['Assembly_ID'].isin(survivor_assembly_ids)]
+    #survivors_list = list(pd.unique(survivors['Obj_name']))
+
+    survivor_map = survivors.set_index('Obj_name')['Assembly_ID'].to_dict()
+    #if len(survivor_map.keys())==0: raise Exception('No surviving components')
+    return survivor_map
+
+def get_component_map(assembly_data, component_list):
+    last_obj_data = assembly_data.sort_values('Iter',ascending=False).drop_duplicates(subset='Obj_name')
+    last_obj_data = last_obj_data[last_obj_data['Obj_name'].isin(component_list)]
+
+    return last_obj_data.set_index('Obj_name')['Assembly_ID'].to_dict()
+
+def collate_QoI(seedlist, base_folder, campaign_seed = 0):
+    root_df = pd.DataFrame()
+    for i_sample, seed in enumerate(seedlist):
+        csv_path = base_folder+'/Campaign_{}/MC_{}/QoI.csv'.format(campaign_seed, i_sample)
+        df = pd.read_csv(str(pathlib.Path(csv_path).resolve()))
+        root_df = pd.concat([root_df,df])
+    output_path = base_folder+'/Campaign_{}/QoI.csv'.format(campaign_seed)
+    root_df.to_csv(str(pathlib.Path(output_path).resolve()))


### PR DESCRIPTION
This PR brings Monte Carlo functionality onto the develop branch in a more user-friendly and extensible way than the existing wrapper on the `uq-dev` branch. The following options are exposed to enable use of the MC layer.

### Uncertainty .cfg Section
Add an `[Uncertainty]` section to a config file to enable control of the Monte Carlo campaign through the following options
- `Num_cores` - Set the number of cores to run the MC campaign on
- `Seed` - Set the base seed of the campaign for repeatability.
- `Yaml_path` - Set the path to the uncertainty *.yaml* file that controls inputs, outputs and distributions.

### Uncertainty .yaml File
Control of which parameters are stochastically varied over the campaign and according to which distribution do they vary is defined by a *.yaml* file of specific structure. An example can be seen in `./Uncertainty/uq_example.yaml`. This file enables the user to select parameters (as defined in the handbook), assign them to uni or multivariate scipy distributions and which output quantities of interest to be tracked on a per-component basis.

### Uncertainty Parameter Handbook
A full list of all exposed parameters that can be used for TITAN UQ can be found in the UQ Parameter Handbook (`./Uncertainty/UQ_parameter_handbook.md`), the aim is for this to be a working document that updates as further functionality for TITAN is developed such that new features are available for stochastic investigation as soon as feasible.

### Additional Updates
In addition to the new MC functions some minor tweaks to the PATO thermal framework have been made.